### PR TITLE
improve goreport by fixing typos and formatting issues

### DIFF
--- a/examples/plugins/gofilesrc/filesrc.go
+++ b/examples/plugins/gofilesrc/filesrc.go
@@ -288,7 +288,7 @@ func (f *fileSrc) Stop(self *base.GstBaseSrc) bool {
 }
 
 // Fill is called to fill a pre-allocated buffer with the data at offset up to the given size.
-// Since we declared that we are seekable, we need to support the provided offset not neccesarily matching
+// Since we declared that we are seekable, we need to support the provided offset not necessarily matching
 // where we currently are in the file. This is why we store the position in the file locally.
 func (f *fileSrc) Fill(self *base.GstBaseSrc, offset uint64, size uint, buffer *gst.Buffer) gst.FlowReturn {
 	if !f.state.started || f.state.file == nil {

--- a/gst/app/gst_app_sink.go
+++ b/gst/app/gst_app_sink.go
@@ -51,7 +51,7 @@ func NewAppSink() (*Sink, error) {
 }
 
 // SinkFromElement checks if the given element is an appsink and if so returns
-// a Sink interace.
+// a Sink interface.
 func SinkFromElement(elem *gst.Element) *Sink {
 	if appSink := C.toGstAppSink(elem.Unsafe()); appSink != nil {
 		return wrapAppSink(elem)

--- a/gst/app/gst_app_src.go
+++ b/gst/app/gst_app_src.go
@@ -55,7 +55,7 @@ func NewAppSrc() (*Source, error) {
 }
 
 // SrcFromElement checks if the given element is an appsrc and if so returns
-// a Source interace.
+// a Source interface.
 func SrcFromElement(elem *gst.Element) *Source {
 	if appSrc := C.toGstAppSrc(elem.Unsafe()); appSrc != nil {
 		return wrapAppSrc(elem)

--- a/gst/audio/gst_audio_info.go
+++ b/gst/audio/gst_audio_info.go
@@ -33,7 +33,7 @@ func wrapInfoFull(ptr *C.GstAudioInfo) *Info {
 }
 
 // Info is a structure used for describing audio properties. This can be filled in from caps
-// or coverted back to caps.
+// or converted back to caps.
 type Info struct {
 	ptr *C.GstAudioInfo
 }

--- a/gst/base/gst_base_src.go
+++ b/gst/base/gst_base_src.go
@@ -103,7 +103,7 @@ func (g *GstBaseSrc) QueryLatency() (ok, live bool, minLatency, maxLatency time.
 // Any blocking operation should be unblocked with the unlock vmethod.
 func (g *GstBaseSrc) SetAsync(async bool) { C.gst_base_src_set_async(g.Instance(), gboolean(async)) }
 
-// SetAutomaticEOS sets whether EOS should be automatically emmitted.
+// SetAutomaticEOS sets whether EOS should be automatically emitted.
 //
 // If automaticEOS is TRUE, src will automatically go EOS if a buffer after the total size is returned. By default
 // this is TRUE but sources that can't return an authoritative size and only know that they're EOS when trying to

--- a/gst/base/gst_collect_pads.go
+++ b/gst/base/gst_collect_pads.go
@@ -223,7 +223,7 @@ var InvalidRunningTime = time.Duration(C.G_MININT64)
 // Since 1.6, this clipping function also sets the DTS parameter of the GstCollectData structure. This version
 // of the running time DTS can be negative. InvalidRunningTime is used to indicate invalid value.
 //
-// data is the CollectData of the cooresponding pad and buf is the buffer being clipped.
+// data is the CollectData of the corresponding pad and buf is the buffer being clipped.
 func (c *CollectPads) ClipRunningTime(data *CollectData, buf *gst.Buffer) (ret gst.FlowReturn, outbuf *gst.Buffer) {
 	var goutbuf *C.GstBuffer
 	ret = gst.FlowReturn(C.gst_collect_pads_clip_running_time(
@@ -335,7 +335,7 @@ func (c *CollectPads) SetClipFunction(f CollectPadsClipFunc) {
 	)
 }
 
-// SetCompareFunction sets the timestamp comparisson function.
+// SetCompareFunction sets the timestamp comparison function.
 func (c *CollectPads) SetCompareFunction(f CollectPadsCompareFunc) {
 	c.funcMap.compareFunc = f
 	C.gst_collect_pads_set_compare_function(

--- a/gst/gst_bus.go
+++ b/gst/gst_bus.go
@@ -122,7 +122,7 @@ func (b *Bus) BlockPopMessage() *Message {
 
 // BusWatchFunc is a go representation of a GstBusFunc. It takes a message as a single argument
 // and returns a bool value for whether to continue processing messages or not. There is no need to unref
-// the message unless addtional references are placed on it during processing.
+// the message unless additional references are placed on it during processing.
 type BusWatchFunc func(msg *Message) bool
 
 // AddWatch adds a watch to the default MainContext for messages emitted on this bus.

--- a/gst/gst_context.go
+++ b/gst/gst_context.go
@@ -29,17 +29,16 @@ func FromGstContextUnsafeNone(ctx unsafe.Pointer) *Context {
 
 // NewContext creates a new context.
 //
-//   // Example
+//	// Example
 //
-//   ctx := gst.NewContext("test-context", false)
-//   fmt.Println(ctx.IsPersistent())
+//	ctx := gst.NewContext("test-context", false)
+//	fmt.Println(ctx.IsPersistent())
 //
-//   ctx = gst.NewContext("test-context", true)
-//   fmt.Println(ctx.IsPersistent())
+//	ctx = gst.NewContext("test-context", true)
+//	fmt.Println(ctx.IsPersistent())
 //
-//   // false
-//   // true
-//
+//	// false
+//	// true
 func NewContext(ctxType string, persistent bool) *Context {
 	cStr := C.CString(ctxType)
 	defer C.free(unsafe.Pointer(cStr))
@@ -55,13 +54,12 @@ func (c *Context) Instance() *C.GstContext { return C.toGstContext(unsafe.Pointe
 
 // GetType returns the type of the context.
 //
-//   // Example
+//	// Example
 //
-//   ctx := gst.NewContext("test-context", false)
-//   fmt.Println(ctx.GetType())
+//	ctx := gst.NewContext("test-context", false)
+//	fmt.Println(ctx.GetType())
 //
-//   // test-context
-//
+//	// test-context
 func (c *Context) GetType() string {
 	return C.GoString(C.gst_context_get_context_type(c.Instance()))
 }
@@ -77,15 +75,14 @@ func (c *Context) GetStructure() *Structure {
 
 // HasContextType checks if the context has the given type.
 //
-//   // Example
+//	// Example
 //
-//   ctx := gst.NewContext("test-context", false)
-//   fmt.Println(ctx.HasContextType("test-context"))
-//   fmt.Println(ctx.HasContextType("another-context"))
+//	ctx := gst.NewContext("test-context", false)
+//	fmt.Println(ctx.HasContextType("test-context"))
+//	fmt.Println(ctx.HasContextType("another-context"))
 //
-//   // true
-//   // false
-//
+//	// true
+//	// false
 func (c *Context) HasContextType(ctxType string) bool {
 	cStr := C.CString(ctxType)
 	defer C.free(unsafe.Pointer(cStr))

--- a/gst/gst_element.go
+++ b/gst/gst_element.go
@@ -168,7 +168,7 @@ func (e *Element) ChangeState(transition StateChange) StateChangeReturn {
 
 // Connect connects to the given signal on this element, and applies f as the callback. The callback must
 // match the signature of the expected callback from the documentation. However, instead of specifying C types
-// for arguments specify the go-gst equivalent (e.g. *gst.Element for almost all GstElement derivitives).
+// for arguments specify the go-gst equivalent (e.g. *gst.Element for almost all GstElement derivatives).
 //
 // This and the Emit() method may get moved down the hierarchy to the Object level at some point, since
 func (e *Element) Connect(signal string, f interface{}) (glib.SignalHandle, error) {

--- a/gst/gst_event_constructors.go
+++ b/gst/gst_event_constructors.go
@@ -65,7 +65,7 @@ func NewFlushStopEvent(resetTime bool) *Event {
 }
 
 // NewGapEvent creates a new GAP event. A gap event can be thought of as conceptually equivalent to a buffer to signal that there is no data for a
-//certain amount of time. This is useful to signal a gap to downstream elements which may wait for data, such as muxers or mixers or overlays,
+// certain amount of time. This is useful to signal a gap to downstream elements which may wait for data, such as muxers or mixers or overlays,
 // especially for sparse streams such as subtitle streams.
 func NewGapEvent(timestamp, duration time.Duration) *Event {
 	return FromGstEventUnsafeFull(unsafe.Pointer(C.gst_event_new_gap(

--- a/gst/gst_meta.go
+++ b/gst/gst_meta.go
@@ -117,7 +117,7 @@ type MetaTransformCopy struct {
 	Size int64
 }
 
-// MetaInfoCallbackFuncs represents callback functions to includ when registering a new
+// MetaInfoCallbackFuncs represents callback functions to include when registering a new
 // meta type.
 type MetaInfoCallbackFuncs struct {
 	InitFunc      MetaInitFunc

--- a/gst/video/convert_frame.go
+++ b/gst/video/convert_frame.go
@@ -27,7 +27,7 @@ import (
 )
 
 // ConvertSampleCallback represents a callback from a video convert opereration.
-// It contains the converted sample or any error that ocurred.
+// It contains the converted sample or any error that occurred.
 type ConvertSampleCallback func(*gst.Sample, error)
 
 // ConvertSample converts a raw video buffer into the specified output caps.

--- a/gst/video/gst_video_format.go
+++ b/gst/video/gst_video_format.go
@@ -159,7 +159,7 @@ const (
 )
 
 // AllFormats is a convenience function for retrieving all formats for inspection purposes.
-// This is not really intended for use in an application, and moreso for debugging.
+// This is not really intended for use in an application, and more so for debugging.
 func AllFormats() []Format {
 	return []Format{
 		FormatI420,


### PR DESCRIPTION
This improves issues from https://goreportcard.com/report/github.com/go-gst/go-gst

in the future the `gofmt` and `mispell` parts of the goreport should also be checked in a Github action