### PR TITLE
Register GstSample marshaling functions (#2)

### DIFF
--- a/gst/gst.go.c
+++ b/gst/gst.go.c
@@ -153,6 +153,13 @@ gboolean        gstObjectFlagIsSet      (GstObject * obj, GstElementFlags flags)
 GstTocSetter *  toTocSetter (GstElement * elem) { return GST_TOC_SETTER(elem); }
 GstTagSetter *  toTagSetter (GstElement *elem)  { return GST_TAG_SETTER(elem); }
 
+/* Sample Utilities */
+
+GstSample * getSampleValue (GValue * val)
+{
+	return gst_value_get_sample(val);
+}
+
 
 /* Misc */
 

--- a/gst/gst.go.h
+++ b/gst/gst.go.h
@@ -132,4 +132,8 @@ extern gpointer glistNext (GList * list);
 
 extern int sizeOfGCharArray (gchar ** arr);
 
+/* Sample Utilities */
+
+extern GstSample * getSampleValue (GValue * val);
+
 #endif

--- a/gst/gst_wrappers.go
+++ b/gst/gst_wrappers.go
@@ -234,6 +234,10 @@ func registerMarshalers() {
 			T: TypeValueList,
 			F: marshalValueList,
 		},
+		{
+			T: glib.Type(C.gst_sample_get_type()),
+			F: marshalSample,
+		},
 	}
 
 	glib.RegisterGValueMarshalers(tm)
@@ -499,4 +503,9 @@ func marshalQuery(p uintptr) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := (*C.GstQuery)(unsafe.Pointer(c))
 	return wrapQuery(obj), nil
+}
+
+func marshalSample(p uintptr) (interface{}, error) {
+	c := C.getSampleValue(toGValue(p))
+	return wrapSample(c), nil
 }


### PR DESCRIPTION
Some of the gstreamer signals, such as the splitmuxsink format-location-full pass a GstSample in the signal callback. We need to register a GstSample marshaling function for this to work.