### PR TITLE
fix memory leak in interpolation control source

### DIFF
--- a/gst/control_source.go
+++ b/gst/control_source.go
@@ -32,7 +32,7 @@ func NewInterpolationControlSource() *InterpolationControlSource {
 	cCs := C.gst_interpolation_control_source_new()
 
 	return &InterpolationControlSource{
-		Object: wrapObject(glib.TransferNone(unsafe.Pointer(cCs))),
+		Object: wrapObject(glib.TransferFull(unsafe.Pointer(cCs))),
 	}
 }
 


### PR DESCRIPTION
An overlook on my part in #1

[gst_interpolation_control_source_new](https://gstreamer.freedesktop.org/documentation/controller/gstinterpolationcontrolsource.html?gi-language=c#gst_interpolation_control_source_new) requires a `transfer:full` instead of `transfer:none`