### PR TITLE
More SEGFAULT safety

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.21
 
 require github.com/mattn/go-pointer v0.0.1
 
-require github.com/go-gst/go-glib v0.0.0-20231204104758-af5ab66d800c
+require github.com/go-gst/go-glib v0.0.0-20231207075824-6d6aaf082c65

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.21
 
 require github.com/mattn/go-pointer v0.0.1
 
-require github.com/go-gst/go-glib v0.0.0-20231129143528-6abb4f7af939
+require github.com/go-gst/go-glib v0.0.0-20231204104758-af5ab66d800c

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.21
 
 require github.com/mattn/go-pointer v0.0.1
 
-require github.com/go-gst/go-glib v0.0.0-20230811085623-0abfebfabe3e
+require github.com/go-gst/go-glib v0.0.0-20231129143528-6abb4f7af939

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/go-gst/go-glib v0.0.0-20231129143528-6abb4f7af939 h1:Z2FvB66fEGvIqzVSOCboWFsoyQgacUR8duoyb43RXAc=
 github.com/go-gst/go-glib v0.0.0-20231129143528-6abb4f7af939/go.mod h1:rXuKU+tCN7pN+b/7oIyWv6MpnlGy+QWd7jRhWUNstjU=
+github.com/go-gst/go-glib v0.0.0-20231204104758-af5ab66d800c h1:F5+xSMyB0KMOt/9LakFnE+74ZKvLrOY3JSDpnMkfKMQ=
+github.com/go-gst/go-glib v0.0.0-20231204104758-af5ab66d800c/go.mod h1:rXuKU+tCN7pN+b/7oIyWv6MpnlGy+QWd7jRhWUNstjU=
 github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o0=
 github.com/mattn/go-pointer v0.0.1/go.mod h1:2zXcozF6qYGgmsG+SeTZz3oAbFLdD3OWqnUbNvJZAlc=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/go-gst/go-glib v0.0.0-20230811085623-0abfebfabe3e h1:ZDMaEJsq1RFfqNQcFcdLbwHYc+quw9YihlwRPkVYeUA=
-github.com/go-gst/go-glib v0.0.0-20230811085623-0abfebfabe3e/go.mod h1:rXuKU+tCN7pN+b/7oIyWv6MpnlGy+QWd7jRhWUNstjU=
+github.com/go-gst/go-glib v0.0.0-20231129143528-6abb4f7af939 h1:Z2FvB66fEGvIqzVSOCboWFsoyQgacUR8duoyb43RXAc=
+github.com/go-gst/go-glib v0.0.0-20231129143528-6abb4f7af939/go.mod h1:rXuKU+tCN7pN+b/7oIyWv6MpnlGy+QWd7jRhWUNstjU=
 github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o0=
 github.com/mattn/go-pointer v0.0.1/go.mod h1:2zXcozF6qYGgmsG+SeTZz3oAbFLdD3OWqnUbNvJZAlc=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
-github.com/go-gst/go-glib v0.0.0-20231129143528-6abb4f7af939 h1:Z2FvB66fEGvIqzVSOCboWFsoyQgacUR8duoyb43RXAc=
-github.com/go-gst/go-glib v0.0.0-20231129143528-6abb4f7af939/go.mod h1:rXuKU+tCN7pN+b/7oIyWv6MpnlGy+QWd7jRhWUNstjU=
-github.com/go-gst/go-glib v0.0.0-20231204104758-af5ab66d800c h1:F5+xSMyB0KMOt/9LakFnE+74ZKvLrOY3JSDpnMkfKMQ=
-github.com/go-gst/go-glib v0.0.0-20231204104758-af5ab66d800c/go.mod h1:rXuKU+tCN7pN+b/7oIyWv6MpnlGy+QWd7jRhWUNstjU=
+github.com/go-gst/go-glib v0.0.0-20231207075824-6d6aaf082c65 h1:G9LRxbnTdpkJAfa6vOwldiWmrtAj2L/7gZlsRZYOITA=
+github.com/go-gst/go-glib v0.0.0-20231207075824-6d6aaf082c65/go.mod h1:rXuKU+tCN7pN+b/7oIyWv6MpnlGy+QWd7jRhWUNstjU=
 github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o0=
 github.com/mattn/go-pointer v0.0.1/go.mod h1:2zXcozF6qYGgmsG+SeTZz3oAbFLdD3OWqnUbNvJZAlc=

--- a/gst/audio/c_util.go
+++ b/gst/audio/c_util.go
@@ -13,6 +13,8 @@ GValue *  audioUtilToGValue (guintptr p) { return (GValue*)(p); }
 */
 import "C"
 import (
+	"unsafe"
+
 	"github.com/go-gst/go-gst/gst"
 )
 
@@ -41,4 +43,6 @@ func gobool(b C.gboolean) bool {
 	return int(b) > 0
 }
 
-func uintptrToGVal(p uintptr) *C.GValue { return (*C.GValue)(C.audioUtilToGValue(C.guintptr(p))) }
+func ptrToGVal(p unsafe.Pointer) *C.GValue {
+	return (*C.GValue)(C.audioUtilToGValue(C.guintptr(p)))
+}

--- a/gst/audio/c_util.go
+++ b/gst/audio/c_util.go
@@ -8,8 +8,6 @@ framesToClockTime (gint frames, gint rate) { return GST_FRAMES_TO_CLOCK_TIME(fra
 
 gint
 clockTimeToFrames(GstClockTime ct, gint rate) { return GST_CLOCK_TIME_TO_FRAMES(ct, rate); }
-
-GValue *  audioUtilToGValue (guintptr p) { return (GValue*)(p); }
 */
 import "C"
 import (
@@ -44,5 +42,5 @@ func gobool(b C.gboolean) bool {
 }
 
 func ptrToGVal(p unsafe.Pointer) *C.GValue {
-	return (*C.GValue)(C.audioUtilToGValue(C.guintptr(p)))
+	return (*C.GValue)(p)
 }

--- a/gst/audio/gst_audio_format.go
+++ b/gst/audio/gst_audio_format.go
@@ -17,8 +17,8 @@ func init() {
 	glib.RegisterGValueMarshalers([]glib.TypeMarshaler{
 		{
 			T: glib.Type(C.gst_audio_format_get_type()),
-			F: func(p uintptr) (interface{}, error) {
-				c := C.g_value_get_enum(uintptrToGVal(p))
+			F: func(p unsafe.Pointer) (interface{}, error) {
+				c := C.g_value_get_enum(ptrToGVal(p))
 				return Format(c), nil
 			},
 		},

--- a/gst/c_util.go
+++ b/gst/c_util.go
@@ -95,15 +95,15 @@ func quarkToString(q C.GQuark) string {
 
 func streamSliceToGlist(streams []*Stream) *C.GList {
 	var glist C.GList
-	wrapped := glib.WrapList(uintptr(unsafe.Pointer(&glist)))
+	wrapped := glib.WrapList(unsafe.Pointer(&glist))
 	for _, stream := range streams {
-		wrapped = wrapped.Append(uintptr(stream.Unsafe()))
+		wrapped = wrapped.Append(stream.Unsafe())
 	}
 	return &glist
 }
 
 func glistToStreamSlice(glist *C.GList) []*Stream {
-	l := glib.WrapList(uintptr(unsafe.Pointer(&glist)))
+	l := glib.WrapList(unsafe.Pointer(&glist))
 	out := make([]*Stream, 0)
 	l.FreeFull(func(item interface{}) {
 		st := item.(*C.GstStream)
@@ -113,7 +113,7 @@ func glistToStreamSlice(glist *C.GList) []*Stream {
 }
 
 func glistToPadTemplateSlice(glist *C.GList) []*PadTemplate {
-	l := glib.WrapList(uintptr(unsafe.Pointer(&glist)))
+	l := glib.WrapList(unsafe.Pointer(&glist))
 	out := make([]*PadTemplate, 0)
 	l.FreeFull(func(item interface{}) {
 		tmpl := item.(*C.GstPadTemplate)

--- a/gst/gst_device_monitor.go
+++ b/gst/gst_device_monitor.go
@@ -62,7 +62,7 @@ func (d *DeviceMonitor) GetDevices() []*Device {
 	if glist == nil {
 		return nil
 	}
-	goList := glib.WrapList(uintptr(unsafe.Pointer(glist)))
+	goList := glib.WrapList(unsafe.Pointer(glist))
 	out := make([]*Device, 0)
 	goList.Foreach(func(item interface{}) {
 		pt := item.(unsafe.Pointer)

--- a/gst/gst_device_provider.go
+++ b/gst/gst_device_provider.go
@@ -30,7 +30,7 @@ func (d *DeviceProvider) GetDevices() []*Device {
 	if glist == nil {
 		return nil
 	}
-	goList := glib.WrapList(uintptr(unsafe.Pointer(glist)))
+	goList := glib.WrapList(unsafe.Pointer(glist))
 	out := make([]*Device, 0)
 	goList.Foreach(func(item interface{}) {
 		pt := item.(unsafe.Pointer)

--- a/gst/gst_element.go
+++ b/gst/gst_element.go
@@ -333,7 +333,7 @@ func (e *Element) GetPadTemplates() []*PadTemplate {
 	if glist == nil {
 		return nil
 	}
-	goList := glib.WrapList(uintptr(unsafe.Pointer(glist)))
+	goList := glib.WrapList(unsafe.Pointer(glist))
 	out := make([]*PadTemplate, 0)
 	goList.Foreach(func(item interface{}) {
 		pt := item.(unsafe.Pointer)

--- a/gst/gst_element_factory.go
+++ b/gst/gst_element_factory.go
@@ -60,14 +60,10 @@ func NewElementWithProperties(factory string, properties map[string]interface{})
 	defer C.free(unsafe.Pointer(cfactory))
 
 	n := C.uint(len(properties))
+	p := unsafe.SliceData(props)
+	v := unsafe.SliceData(values)
 
-	var elem *C.GstElement
-
-	if n > 0 {
-		elem = C.gst_element_factory_make_with_properties(cfactory, n, &props[0], &values[0])
-	} else {
-		elem = C.gst_element_factory_make_with_properties(cfactory, n, nil, nil)
-	}
+	elem := C.gst_element_factory_make_with_properties(cfactory, n, p, v)
 
 	if elem == nil {
 		return nil, fmt.Errorf("could not create element: %s", factory)

--- a/gst/gst_element_factory.go
+++ b/gst/gst_element_factory.go
@@ -5,6 +5,7 @@ import "C"
 
 import (
 	"fmt"
+	"runtime"
 	"unsafe"
 
 	"github.com/go-gst/go-glib/glib"
@@ -47,13 +48,16 @@ func NewElementWithProperties(factory string, properties map[string]interface{})
 
 		props = append(props, cpropName)
 
-		cValue, err := glib.GValue(v)
+		value, err := glib.GValue(v)
 
 		if err != nil {
 			return nil, err
 		}
 
-		values = append(values, *(*C.GValue)(cValue.Unsafe()))
+		// value goes out of scope, but the finalizer must not run until the cgo call is finished
+		defer runtime.KeepAlive(value)
+
+		values = append(values, *(*C.GValue)(value.Unsafe()))
 	}
 
 	cfactory := C.CString(factory)

--- a/gst/gst_pad_exports.go
+++ b/gst/gst_pad_exports.go
@@ -130,7 +130,7 @@ func goGstPadIterIntLinkFunction(pad *C.GstPad, parent *C.GstObject) *C.GstItera
 		if err != nil {
 			return nil
 		}
-		val.SetInstance(uintptr(unsafe.Pointer(pads[0].Instance())))
+		val.SetInstance(unsafe.Pointer(pads[0].Instance()))
 		return C.gst_iterator_new_single(C.gst_pad_get_type(), (*C.GValue)(unsafe.Pointer(val.GValue)))
 	}
 	return nil

--- a/gst/gst_wrappers.go
+++ b/gst/gst_wrappers.go
@@ -243,23 +243,23 @@ func registerMarshalers() {
 	glib.RegisterGValueMarshalers(tm)
 }
 
-func toGValue(p uintptr) *C.GValue {
-	return (*C.GValue)((unsafe.Pointer)(p))
+func toGValue(p unsafe.Pointer) *C.GValue {
+	return (*C.GValue)(p)
 }
 
-func marshalValueArray(p uintptr) (interface{}, error) {
+func marshalValueArray(p unsafe.Pointer) (interface{}, error) {
 	val := toGValue(p)
 	out := ValueArrayValue(*glib.ValueFromNative(unsafe.Pointer(val)))
 	return &out, nil
 }
 
-func marshalValueList(p uintptr) (interface{}, error) {
-	val := glib.ValueFromNative(unsafe.Pointer(toGValue(p)))
+func marshalValueList(p unsafe.Pointer) (interface{}, error) {
+	val := glib.ValueFromNative(p)
 	out := ValueListValue(*glib.ValueFromNative(unsafe.Pointer(val)))
 	return &out, nil
 }
 
-func marshalInt64Range(p uintptr) (interface{}, error) {
+func marshalInt64Range(p unsafe.Pointer) (interface{}, error) {
 	v := toGValue(p)
 	return &Int64RangeValue{
 		start: int64(C.gst_value_get_int64_range_min(v)),
@@ -268,7 +268,7 @@ func marshalInt64Range(p uintptr) (interface{}, error) {
 	}, nil
 }
 
-func marshalIntRange(p uintptr) (interface{}, error) {
+func marshalIntRange(p unsafe.Pointer) (interface{}, error) {
 	v := toGValue(p)
 	return &IntRangeValue{
 		start: int(C.gst_value_get_int_range_min(v)),
@@ -277,12 +277,12 @@ func marshalIntRange(p uintptr) (interface{}, error) {
 	}, nil
 }
 
-func marshalBitmask(p uintptr) (interface{}, error) {
+func marshalBitmask(p unsafe.Pointer) (interface{}, error) {
 	v := toGValue(p)
 	return Bitmask(C.gst_value_get_bitmask(v)), nil
 }
 
-func marshalFlagset(p uintptr) (interface{}, error) {
+func marshalFlagset(p unsafe.Pointer) (interface{}, error) {
 	v := toGValue(p)
 	return &FlagsetValue{
 		flags: uint(C.gst_value_get_flagset_flags(v)),
@@ -290,7 +290,7 @@ func marshalFlagset(p uintptr) (interface{}, error) {
 	}, nil
 }
 
-func marshalDoubleRange(p uintptr) (interface{}, error) {
+func marshalDoubleRange(p unsafe.Pointer) (interface{}, error) {
 	v := toGValue(p)
 	return &Float64RangeValue{
 		start: float64(C.gst_value_get_double_range_min(v)),
@@ -298,7 +298,7 @@ func marshalDoubleRange(p uintptr) (interface{}, error) {
 	}, nil
 }
 
-func marshalFraction(p uintptr) (interface{}, error) {
+func marshalFraction(p unsafe.Pointer) (interface{}, error) {
 	v := toGValue(p)
 	out := &FractionValue{
 		num:   int(C.gst_value_get_fraction_numerator(v)),
@@ -307,7 +307,7 @@ func marshalFraction(p uintptr) (interface{}, error) {
 	return out, nil
 }
 
-func marshalFractionRange(p uintptr) (interface{}, error) {
+func marshalFractionRange(p unsafe.Pointer) (interface{}, error) {
 	v := toGValue(p)
 	start := C.gst_value_get_fraction_range_min(v)
 	end := C.gst_value_get_fraction_range_max(v)
@@ -317,195 +317,195 @@ func marshalFractionRange(p uintptr) (interface{}, error) {
 	}, nil
 }
 
-func marshalBufferingMode(p uintptr) (interface{}, error) {
+func marshalBufferingMode(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_enum(toGValue(p))
 	return BufferingMode(c), nil
 }
 
-func marshalFormat(p uintptr) (interface{}, error) {
+func marshalFormat(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_enum(toGValue(p))
 	return Format(c), nil
 }
 
-func marshalMessageType(p uintptr) (interface{}, error) {
+func marshalMessageType(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_enum(toGValue(p))
 	return MessageType(c), nil
 }
 
-func marshalPadLinkReturn(p uintptr) (interface{}, error) {
+func marshalPadLinkReturn(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_enum(toGValue(p))
 	return PadLinkReturn(c), nil
 }
 
-func marshalState(p uintptr) (interface{}, error) {
+func marshalState(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_enum(toGValue(p))
 	return State(c), nil
 }
 
-func marshalSeekFlags(p uintptr) (interface{}, error) {
+func marshalSeekFlags(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_enum(toGValue(p))
 	return SeekFlags(c), nil
 }
 
-func marshalSeekType(p uintptr) (interface{}, error) {
+func marshalSeekType(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_enum(toGValue(p))
 	return SeekType(c), nil
 }
 
-func marshalStateChangeReturn(p uintptr) (interface{}, error) {
+func marshalStateChangeReturn(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_enum(toGValue(p))
 	return StateChangeReturn(c), nil
 }
 
-func marshalGhostPad(p uintptr) (interface{}, error) {
+func marshalGhostPad(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := &glib.Object{GObject: glib.ToGObject(unsafe.Pointer(c))}
 	return wrapGhostPad(obj), nil
 }
 
-func marshalProxyPad(p uintptr) (interface{}, error) {
+func marshalProxyPad(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := &glib.Object{GObject: glib.ToGObject(unsafe.Pointer(c))}
 	return wrapProxyPad(obj), nil
 }
 
-func marshalPad(p uintptr) (interface{}, error) {
+func marshalPad(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := &glib.Object{GObject: glib.ToGObject(unsafe.Pointer(c))}
 	return wrapPad(obj), nil
 }
 
-func marshalMessage(p uintptr) (interface{}, error) {
+func marshalMessage(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_boxed(toGValue(p))
 	return &Message{(*C.GstMessage)(unsafe.Pointer(c))}, nil
 }
 
-func marshalObject(p uintptr) (interface{}, error) {
+func marshalObject(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := &glib.Object{GObject: glib.ToGObject(unsafe.Pointer(c))}
 	return wrapObject(obj), nil
 }
 
-func marshalBus(p uintptr) (interface{}, error) {
+func marshalBus(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := &glib.Object{GObject: glib.ToGObject(unsafe.Pointer(c))}
 	return wrapBus(obj), nil
 }
 
-func marshalElementFactory(p uintptr) (interface{}, error) {
+func marshalElementFactory(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := &glib.Object{GObject: glib.ToGObject(unsafe.Pointer(c))}
 	return wrapElementFactory(obj), nil
 }
 
-func marshalPipeline(p uintptr) (interface{}, error) {
+func marshalPipeline(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := &glib.Object{GObject: glib.ToGObject(unsafe.Pointer(c))}
 	return wrapPipeline(obj), nil
 }
 
-func marshalPluginFeature(p uintptr) (interface{}, error) {
+func marshalPluginFeature(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := &glib.Object{GObject: glib.ToGObject(unsafe.Pointer(c))}
 	return wrapPluginFeature(obj), nil
 }
 
-func marshalElement(p uintptr) (interface{}, error) {
+func marshalElement(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := &glib.Object{GObject: glib.ToGObject(unsafe.Pointer(c))}
 	return wrapElement(obj), nil
 }
 
-func marshalBin(p uintptr) (interface{}, error) {
+func marshalBin(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := &glib.Object{GObject: glib.ToGObject(unsafe.Pointer(c))}
 	return wrapBin(obj), nil
 }
 
-func marshalAllocationParams(p uintptr) (interface{}, error) {
+func marshalAllocationParams(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := (*C.GstAllocationParams)(unsafe.Pointer(c))
 	return wrapAllocationParams(obj), nil
 }
 
-func marshalMemory(p uintptr) (interface{}, error) {
+func marshalMemory(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := (*C.GstMemory)(unsafe.Pointer(c))
 	return wrapMemory(obj), nil
 }
 
-func marshalBuffer(p uintptr) (interface{}, error) {
+func marshalBuffer(p unsafe.Pointer) (interface{}, error) {
 	c := C.getBufferValue(toGValue(p))
 	return wrapBuffer(c), nil
 }
 
-func marshalBufferList(p uintptr) (interface{}, error) {
+func marshalBufferList(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := (*C.GstBufferList)(unsafe.Pointer(c))
 	return wrapBufferList(obj), nil
 }
 
-func marshalCaps(p uintptr) (interface{}, error) {
+func marshalCaps(p unsafe.Pointer) (interface{}, error) {
 	c := C.gst_value_get_caps(toGValue(p))
 	obj := (*C.GstCaps)(unsafe.Pointer(c))
 	return wrapCaps(obj), nil
 }
 
-func marshalCapsFeatures(p uintptr) (interface{}, error) {
+func marshalCapsFeatures(p unsafe.Pointer) (interface{}, error) {
 	c := C.gst_value_get_caps_features(toGValue(p))
 	obj := (*C.GstCapsFeatures)(unsafe.Pointer(c))
 	return wrapCapsFeatures(obj), nil
 }
 
-func marshalStructure(p uintptr) (interface{}, error) {
+func marshalStructure(p unsafe.Pointer) (interface{}, error) {
 	c := C.gst_value_get_structure(toGValue(p))
 	obj := (*C.GstStructure)(unsafe.Pointer(c))
 	return wrapStructure(obj), nil
 }
 
-func marshalContext(p uintptr) (interface{}, error) {
+func marshalContext(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := (*C.GstContext)(unsafe.Pointer(c))
 	return wrapContext(obj), nil
 }
 
-func marshalTOC(p uintptr) (interface{}, error) {
+func marshalTOC(p unsafe.Pointer) (interface{}, error) {
 	c := C.gst_value_get_structure(toGValue(p))
 	obj := (*C.GstToc)(unsafe.Pointer(c))
 	return wrapTOC(obj), nil
 }
 
-func marshalTOCEntry(p uintptr) (interface{}, error) {
+func marshalTOCEntry(p unsafe.Pointer) (interface{}, error) {
 	c := C.gst_value_get_structure(toGValue(p))
 	obj := (*C.GstTocEntry)(unsafe.Pointer(c))
 	return wrapTOCEntry(obj), nil
 }
 
-func marsalTagList(p uintptr) (interface{}, error) {
+func marsalTagList(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := (*C.GstTagList)(unsafe.Pointer(c))
 	return wrapTagList(obj), nil
 }
 
-func marshalEvent(p uintptr) (interface{}, error) {
+func marshalEvent(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := (*C.GstEvent)(unsafe.Pointer(c))
 	return wrapEvent(obj), nil
 }
 
-func marshalSegment(p uintptr) (interface{}, error) {
+func marshalSegment(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := (*C.GstSegment)(unsafe.Pointer(c))
 	return wrapSegment(obj), nil
 }
 
-func marshalQuery(p uintptr) (interface{}, error) {
+func marshalQuery(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object(toGValue(p))
 	obj := (*C.GstQuery)(unsafe.Pointer(c))
 	return wrapQuery(obj), nil
 }
 
-func marshalSample(p uintptr) (interface{}, error) {
+func marshalSample(p unsafe.Pointer) (interface{}, error) {
 	c := C.getSampleValue(toGValue(p))
 	return FromGstSampleUnsafeNone(unsafe.Pointer(c)), nil
 }

--- a/gst/pbutils/discoverer.go
+++ b/gst/pbutils/discoverer.go
@@ -16,50 +16,50 @@ func init() {
 	tm := []glib.TypeMarshaler{
 		{
 			T: glib.Type(C.gst_discoverer_get_type()),
-			F: func(p uintptr) (interface{}, error) {
-				c := C.g_value_get_object(uintptrToGVal(p))
+			F: func(p unsafe.Pointer) (interface{}, error) {
+				c := C.g_value_get_object(ptrToGVal(p))
 				return &Discoverer{toGObject(unsafe.Pointer(c))}, nil
 			},
 		},
 		{
 			T: glib.Type(C.gst_discoverer_info_get_type()),
-			F: func(p uintptr) (interface{}, error) {
-				c := C.g_value_get_object(uintptrToGVal(p))
+			F: func(p unsafe.Pointer) (interface{}, error) {
+				c := C.g_value_get_object(ptrToGVal(p))
 				return &DiscovererInfo{toGObject(unsafe.Pointer(c))}, nil
 			},
 		},
 		{
 			T: glib.Type(C.gst_discoverer_stream_info_get_type()),
-			F: func(p uintptr) (interface{}, error) {
-				c := C.g_value_get_object(uintptrToGVal(p))
+			F: func(p unsafe.Pointer) (interface{}, error) {
+				c := C.g_value_get_object(ptrToGVal(p))
 				return &DiscovererStreamInfo{toGObject(unsafe.Pointer(c))}, nil
 			},
 		},
 		{
 			T: glib.Type(C.gst_discoverer_audio_info_get_type()),
-			F: func(p uintptr) (interface{}, error) {
-				c := C.g_value_get_object(uintptrToGVal(p))
+			F: func(p unsafe.Pointer) (interface{}, error) {
+				c := C.g_value_get_object(ptrToGVal(p))
 				return &DiscovererAudioInfo{&DiscovererStreamInfo{toGObject(unsafe.Pointer(c))}}, nil
 			},
 		},
 		{
 			T: glib.Type(C.gst_discoverer_video_info_get_type()),
-			F: func(p uintptr) (interface{}, error) {
-				c := C.g_value_get_object(uintptrToGVal(p))
+			F: func(p unsafe.Pointer) (interface{}, error) {
+				c := C.g_value_get_object(ptrToGVal(p))
 				return &DiscovererVideoInfo{&DiscovererStreamInfo{toGObject(unsafe.Pointer(c))}}, nil
 			},
 		},
 		{
 			T: glib.Type(C.gst_discoverer_subtitle_info_get_type()),
-			F: func(p uintptr) (interface{}, error) {
-				c := C.g_value_get_object(uintptrToGVal(p))
+			F: func(p unsafe.Pointer) (interface{}, error) {
+				c := C.g_value_get_object(ptrToGVal(p))
 				return &DiscovererSubtitleInfo{&DiscovererStreamInfo{toGObject(unsafe.Pointer(c))}}, nil
 			},
 		},
 		{
 			T: glib.Type(C.gst_discoverer_container_info_get_type()),
-			F: func(p uintptr) (interface{}, error) {
-				c := C.g_value_get_object(uintptrToGVal(p))
+			F: func(p unsafe.Pointer) (interface{}, error) {
+				c := C.g_value_get_object(ptrToGVal(p))
 				return &DiscovererContainerInfo{&DiscovererStreamInfo{toGObject(unsafe.Pointer(c))}}, nil
 			},
 		},
@@ -67,9 +67,8 @@ func init() {
 	glib.RegisterGValueMarshalers(tm)
 }
 
-func uintptrToGVal(p uintptr) *C.GValue {
-	return (*C.GValue)(unsafe.Pointer(p)) // vet thinks this is unsafe and there is no way around it for now.
-	// but the given ptr is an address to a C object so go's concerns are misplaced.
+func ptrToGVal(p unsafe.Pointer) *C.GValue {
+	return (*C.GValue)(p)
 }
 
 func toGObject(o unsafe.Pointer) *glib.Object { return &glib.Object{GObject: glib.ToGObject(o)} }

--- a/gst/video/gst_color_balance.go
+++ b/gst/video/gst_color_balance.go
@@ -100,7 +100,7 @@ func (c *gstColorBalance) ListChannels() []*ColorBalanceChannel {
 	if gList == nil {
 		return nil
 	}
-	wrapped := glib.WrapList(uintptr(unsafe.Pointer(gList)))
+	wrapped := glib.WrapList(unsafe.Pointer(gList))
 	defer wrapped.Free()
 	out := make([]*ColorBalanceChannel, 0)
 	wrapped.Foreach(func(item interface{}) {

--- a/gst/video/gst_video_format.go
+++ b/gst/video/gst_video_format.go
@@ -44,8 +44,8 @@ func init() {
 	glib.RegisterGValueMarshalers([]glib.TypeMarshaler{
 		{
 			T: glib.Type(C.gst_video_format_get_type()),
-			F: func(p uintptr) (interface{}, error) {
-				c := C.g_value_get_enum(uintptrToGVal(p))
+			F: func(p unsafe.Pointer) (interface{}, error) {
+				c := C.g_value_get_enum(ptrToGVal(p))
 				return Format(c), nil
 			},
 		},

--- a/gst/video/gst_video_format.go
+++ b/gst/video/gst_video_format.go
@@ -45,7 +45,7 @@ func init() {
 		{
 			T: glib.Type(C.gst_video_format_get_type()),
 			F: func(p unsafe.Pointer) (interface{}, error) {
-				c := C.g_value_get_enum(ptrToGVal(p))
+				c := C.g_value_get_enum((*C.GValue)(p))
 				return Format(c), nil
 			},
 		},


### PR DESCRIPTION
closes #61 

This removes all uses of `uintptr` across the bindings and also fixes a possible GC related SIGSEGV in `glib.SetProperty` with https://github.com/go-gst/go-glib/pull/3