### PR TITLE
allow for gst.Element as properties to other gst.Elements

### DIFF
--- a/gst/gst_element.go
+++ b/gst/gst_element.go
@@ -625,3 +625,15 @@ func (e *Element) SeekTime(position time.Duration, flag SeekFlags) bool {
 func (e *Element) SeekDefault(position int64, flag SeekFlags) bool {
 	return e.SeekSimple(position, FormatDefault, flag)
 }
+
+// this prevents go pointers in cgo when setting a gst.Element to a property
+// see (https://github.com/go-gst/go-gst/issues/65)
+// ToGValue implements glib.ValueTransformer.
+func (e *Element) ToGValue() (*glib.Value, error) {
+	val, err := glib.ValueInit(glib.Type(C.GST_TYPE_ELEMENT))
+	if err != nil {
+		return nil, err
+	}
+	val.SetInstance(unsafe.Pointer(e.Instance()))
+	return val, nil
+}


### PR DESCRIPTION
see https://github.com/go-gst/go-gst/issues/65

allows for runninng the following without errors:

```go
package main

import (
	"fmt"

	"github.com/go-gst/go-gst/gst"
)

func main() {
	gst.Init(nil)

	// Testing code goes here

	sink, _ := gst.NewElement("splitmuxsink")

	mux, _ := gst.NewElement("webmmux")

	if err := sink.SetProperty("muxer", mux); err != nil {
		fmt.Println("failed to set element to splitmuxsink: ", err)
	}
}
```