### PR TITLE
Fix remove bus watch leak

### DIFF
--- a/buildAll.sh
+++ b/buildAll.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # this script builds all go packages in the current directory
 

--- a/gst/cgo_exports.go
+++ b/gst/cgo_exports.go
@@ -274,3 +274,10 @@ func goLogFunction(
 		)
 	}
 }
+
+// goDestroyBusWatch frees the go memory associated with the bus watch.
+//
+//export goDestroyBusWatch
+func goDestroyBusWatch(fPtr C.gpointer) {
+	gopointer.Unref(unsafe.Pointer(fPtr))
+}


### PR DESCRIPTION
fixes #107 

Analogous to the rust bindings: https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/-/blob/main/gstreamer/src/bus.rs#L141-160

use [`gst_bus_add_watch_full`](https://gstreamer.freedesktop.org/documentation/gstreamer/gstbus.html?gi-language=c#gst_bus_add_watch_full) to be able to attach a notify function for the cleanup.