### PR TITLE
Avoid double free in gst_bus watch function handler

### DIFF
--- a/gst/cgo_exports.go
+++ b/gst/cgo_exports.go
@@ -125,7 +125,6 @@ func goBusFunc(bus *C.GstBus, cMsg *C.GstMessage, userData C.gpointer) C.gboolea
 
 	// run the call back
 	if cont := busFunc(msg); !cont {
-		gopointer.Unref(ptr)
 		return gboolean(false)
 	}
 


### PR DESCRIPTION
This PR is an attempt at fixing https://github.com/go-gst/go-gst/issues/123. if the busFunc callback returns that the callback should be removed, it currently frees the user_data passed into gst_bus_add_watch_full. However, `AddWatch` in got_bus.go also defined a destroy notify handler that gets called in this case, causing the double free. 

This fix is verified to fix the double free in my case. Another PR will be created soon that removes other calls to `gopointer.Unref` that I believe would cause double free as well, from my understanding of the go-gst code, but are not tested as thoroughly. 