### PR TITLE
Avoid double free in misc callback handlers

### DIFF
--- a/gst/cgo_exports.go
+++ b/gst/cgo_exports.go
@@ -10,7 +10,6 @@ package gst
 import "C"
 
 import (
-	"fmt"
 	"unsafe"
 
 	"github.com/go-gst/go-glib/glib"
@@ -118,15 +117,11 @@ func goBusFunc(bus *C.GstBus, cMsg *C.GstMessage, userData C.gpointer) C.gboolea
 	funcIface := gopointer.Restore(ptr)
 	busFunc, ok := funcIface.(BusWatchFunc)
 	if !ok {
-		fmt.Println("goBusFunc unref", ptr)
-		gopointer.Unref(ptr)
 		return gboolean(false)
 	}
 
 	// run the call back
 	if cont := busFunc(msg); !cont {
-		fmt.Println("goBusFunc unref 2", ptr)
-		gopointer.Unref(ptr)
 		return gboolean(false)
 	}
 
@@ -204,7 +199,6 @@ func goCapsMapFunc(features *C.GstCapsFeatures, structure *C.GstStructure, userD
 	mapFunc, ok := funcIface.(CapsMapFunc)
 
 	if !ok {
-		gopointer.Unref(ptr)
 		return gboolean(false)
 	}
 
@@ -219,7 +213,6 @@ func goClockCb(gclock *C.GstClock, clockTime C.GstClockTime, clockID C.GstClockI
 	cb, ok := funcIface.(ClockCallback)
 
 	if !ok {
-		gopointer.Unref(ptr)
 		return gboolean(false)
 	}
 

--- a/gst/gst_bus.go
+++ b/gst/gst_bus.go
@@ -26,7 +26,6 @@ GstBusSyncReply cgoBusSyncHandler (GstBus * bus, GstMessage * message, gpointer 
 import "C"
 
 import (
-	"fmt"
 	"reflect"
 	"unsafe"
 
@@ -136,7 +135,6 @@ type BusWatchFunc func(msg *Message) bool
 // is already a function registered.
 func (b *Bus) AddWatch(busFunc BusWatchFunc) bool {
 	fPtr := gopointer.Save(busFunc)
-	fmt.Println("AddWatch", fPtr)
 	return gobool(
 		C.int(C.gst_bus_add_watch_full(
 			b.Instance(),
@@ -306,7 +304,6 @@ type BusSyncHandler func(msg *Message) BusSyncReply
 // Currently, destroyNotify funcs are not supported.
 func (b *Bus) SetSyncHandler(f BusSyncHandler) {
 	ptr := gopointer.Save(f)
-	fmt.Println("SetSyncHandler", ptr)
 	C.gst_bus_set_sync_handler(
 		b.Instance(),
 		C.GstBusSyncHandler(C.cgoBusSyncHandler),

--- a/gst/gst_bus.go
+++ b/gst/gst_bus.go
@@ -26,6 +26,7 @@ GstBusSyncReply cgoBusSyncHandler (GstBus * bus, GstMessage * message, gpointer 
 import "C"
 
 import (
+	"fmt"
 	"reflect"
 	"unsafe"
 
@@ -135,6 +136,7 @@ type BusWatchFunc func(msg *Message) bool
 // is already a function registered.
 func (b *Bus) AddWatch(busFunc BusWatchFunc) bool {
 	fPtr := gopointer.Save(busFunc)
+	fmt.Println("AddWatch", fPtr)
 	return gobool(
 		C.int(C.gst_bus_add_watch_full(
 			b.Instance(),
@@ -304,6 +306,7 @@ type BusSyncHandler func(msg *Message) BusSyncReply
 // Currently, destroyNotify funcs are not supported.
 func (b *Bus) SetSyncHandler(f BusSyncHandler) {
 	ptr := gopointer.Save(f)
+	fmt.Println("SetSyncHandler", ptr)
 	C.gst_bus_set_sync_handler(
 		b.Instance(),
 		C.GstBusSyncHandler(C.cgoBusSyncHandler),


### PR DESCRIPTION
This PR is the result of my investigation of https://github.com/go-gst/go-gst/issues/123. While https://github.com/go-gst/go-gst/pull/126 addresses the specific double free that was causing a crash in my case, I believe some other calls to gopointer.Unref in other gstreamer callbacks have a similar issue: they free the user data in some error, or callback remove cases, while also defining a "destroy" callback that gstreamer will call to cleanup the user_data.

These fixes are not entirely tested as I lack use cases to test them. Would you have a suggestion of code to run to test them?