### PR TITLE
Async state change plugin example

### DIFF
--- a/examples/plugins/async-identity/asyncidentity.go
+++ b/examples/plugins/async-identity/asyncidentity.go
@@ -1,0 +1,232 @@
+//lint:file-ignore U1000 Ignore all unused code, this is example code
+
+// +plugin:Name=async-identity
+// +plugin:Description=A go-gst example plugin with async state changes
+// +plugin:Version=v0.0.1
+// +plugin:License=gst.LicenseLGPL
+// +plugin:Source=go-gst
+// +plugin:Package=examples
+// +plugin:Origin=https://github.com/go-gst/go-gst
+// +plugin:ReleaseDate=2024-09-13
+//
+// +element:Name=asyncidentity
+// +element:Rank=gst.RankNone
+// +element:Impl=asyncidentity
+// +element:Subclass=gst.ExtendsElement
+//
+//go:generate gst-plugin-gen
+package main
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-gst/go-glib/glib"
+	"github.com/go-gst/go-gst/gst"
+)
+
+var (
+	_cat = gst.NewDebugCategory(
+		"asyncidentity",
+		gst.DebugColorNone,
+		"asyncidentity element",
+	)
+
+	_srcPadTemplate = gst.NewPadTemplate("generic-src", gst.PadDirectionSource,
+		gst.PadPresenceAlways, gst.NewAnyCaps())
+	_sinkPadTemplate = gst.NewPadTemplate("generic-sink", gst.PadDirectionSink,
+		gst.PadPresenceAlways, gst.NewAnyCaps())
+	_properties = []*glib.ParamSpec{
+		glib.NewUint64Param(
+			"delay",
+			"ns state change delay",
+			"Duration in nanoseconds to wait until a state changes",
+			_delayNsMin, _delayNsMax, _delayNsDefault,
+			glib.ParameterReadWrite,
+		),
+	}
+)
+
+const (
+	_propDelayNs = 0
+
+	_delayNsMin     = uint64(0)
+	_delayNsMax     = uint64(time.Second) * 10
+	_delayNsDefault = uint64(time.Second)
+)
+
+func main() {}
+
+type asyncidentity struct {
+	// inner state
+	sinkpad *gst.Pad
+	srcpad  *gst.Pad
+
+	asyncPending atomic.Bool
+
+	// property storage
+	delayNs atomic.Uint64
+}
+
+var _ glib.GoObjectSubclass = (*asyncidentity)(nil)
+
+func (g *asyncidentity) New() glib.GoObjectSubclass { return &asyncidentity{} }
+
+func (g *asyncidentity) ClassInit(klass *glib.ObjectClass) {
+	class := gst.ToElementClass(klass)
+	class.SetMetadata(
+		"Async Identity Example",
+		"General",
+		"An async state changing identity like element",
+		"Artem Martus <artemmartus2012@gmail.com>",
+	)
+
+	class.AddStaticPadTemplate(_srcPadTemplate)
+	class.AddStaticPadTemplate(_sinkPadTemplate)
+
+	class.InstallProperties(_properties)
+}
+
+var _ glib.GoObject = (*asyncidentity)(nil)
+
+func (g *asyncidentity) SetProperty(obj *glib.Object, id uint, value *glib.Value) {
+	self := gst.ToElement(obj)
+
+	switch id {
+	case _propDelayNs:
+		newDelayErased, err := value.GoValue()
+		if err != nil {
+			self.Error("Failed unmarshalling the 'delay' property", err)
+			return
+		}
+		newDelay, ok := newDelayErased.(uint64)
+		if !ok {
+			self.Error("Failed Go-casting the 'delay' interface{} into uint64",
+				fmt.Errorf("interfaced value: %+v", newDelayErased))
+			return
+		}
+		oldDelay := g.delayNs.Swap(newDelay)
+
+		self.Log(_cat, gst.LevelInfo,
+			fmt.Sprintf("Changed delay property %s => %s",
+				time.Duration(oldDelay),
+				time.Duration(newDelay),
+			))
+	default:
+		self.Error("Tried to set unknown property",
+			fmt.Errorf("prop id %d: %s", id, value.TypeName()))
+	}
+}
+
+func (g *asyncidentity) GetProperty(obj *glib.Object, id uint) *glib.Value {
+	var (
+		out *glib.Value
+		err error
+	)
+
+	switch id {
+	case _propDelayNs:
+		out, err = glib.GValue(g.delayNs.Load())
+	default:
+		err = fmt.Errorf("unknown property id: %d", id)
+	}
+
+	if err != nil {
+		self := gst.ToElement(obj)
+		self.Error("Get property error", err)
+		out = nil
+	}
+
+	return out
+}
+
+func (g *asyncidentity) Constructed(self *glib.Object) {
+	elem := gst.ToElement(self)
+	srcPad := gst.NewPadFromTemplate(_srcPadTemplate, "src")
+	sinkPad := gst.NewPadFromTemplate(_sinkPadTemplate, "sink")
+
+	sinkPad.SetChainFunction(g.sink_chain_function)
+
+	// Have to set proxy flags on a pads
+	proxyFlags := gst.PadFlagProxyAllocation | gst.PadFlagProxyCaps | gst.PadFlagProxyScheduling
+	sinkPad.SetFlags(proxyFlags)
+	srcPad.SetFlags(proxyFlags)
+
+	// Or setup query & event functions like so
+
+	// sinkPad.SetQueryFunction(func(self *gst.Pad, parent *gst.Object, query *gst.Query) bool {
+	// 	return srcPad.PeerQuery(query)
+	// })
+	// sinkPad.SetEventFunction(func(self *gst.Pad, parent *gst.Object, event *gst.Event) bool {
+	// 	return srcPad.PushEvent(event)
+	// })
+
+	// srcPad.SetQueryFunction(func(self *gst.Pad, parent *gst.Object, query *gst.Query) bool {
+	// 	return sinkPad.PeerQuery(query)
+	// })
+	// srcPad.SetEventFunction(func(self *gst.Pad, parent *gst.Object, event *gst.Event) bool {
+	// 	return sinkPad.PushEvent(event)
+	// })
+
+	elem.AddPad(srcPad)
+	elem.AddPad(sinkPad)
+
+	g.srcpad = srcPad
+	g.sinkpad = sinkPad
+
+	g.delayNs.Store(_delayNsDefault)
+}
+
+func (g *asyncidentity) sink_chain_function(
+	_self *gst.Pad,
+	_parent *gst.Object,
+	buffer *gst.Buffer,
+) gst.FlowReturn {
+
+	return g.srcpad.Push(buffer)
+}
+
+// var _ gst.ElementImpl = (*asyncidentity)(nil)
+
+func (g *asyncidentity) ChangeState(el *gst.Element, transition gst.StateChange) gst.StateChangeReturn {
+	if ret := el.ParentChangeState(transition); ret == gst.StateChangeFailure {
+		return ret
+	}
+
+	switch transition {
+	case gst.StateChangeNullToReady:
+		// async will be ignored due to target state <= READY
+	case gst.StateChangeReadyToPaused:
+		// async will be ignored due to no_preroll
+		return gst.StateChangeNoPreroll
+	case gst.StateChangePausedToPlaying:
+		fallthrough
+	case gst.StateChangePlayingToPaused:
+		g.asyncStateChange(el)
+		return gst.StateChangeAsync
+	case gst.StateChangePausedToReady:
+		// async will be ignored due to target state <= READY
+	case gst.StateChangeReadyToNull:
+	}
+
+	// check against forcing state change
+	if g.asyncPending.Load() {
+		return gst.StateChangeAsync
+	}
+
+	return gst.StateChangeSuccess
+}
+
+func (g *asyncidentity) asyncStateChange(el *gst.Element) {
+	msg := gst.NewAsyncStartMessage(el)
+	_ = el.PostMessage(msg)
+	go func(el *gst.Element) {
+		g.asyncPending.Store(true)
+		delay := time.Duration(g.delayNs.Load())
+		<-time.After(delay)
+		msg := gst.NewAsyncDoneMessage(el, gst.ClockTimeNone)
+		_ = el.PostMessage(msg)
+		g.asyncPending.Store(false)
+	}(el)
+}

--- a/gst/gst.go.c
+++ b/gst/gst.go.c
@@ -149,13 +149,15 @@ GstTagList *     makeTagListWritable   (GstTagList * tagList)   { return gst_tag
 
 /* Object Utilities */
 
-gboolean        gstElementIsURIHandler  (GstElement * elem)                      { return (GST_IS_URI_HANDLER(elem)); }
-gboolean        gstObjectFlagIsSet      (GstObject * obj, GstElementFlags flags) { return (GST_OBJECT_FLAG_IS_SET(obj, flags)); }
+gboolean        gstObjectFlagIsSet      (GstObject * obj, guint32 flags) { return (GST_OBJECT_FLAG_IS_SET(obj, flags)); }
+void            gstObjectFlagSet        (GstObject * obj, guint32 flags) { (GST_OBJECT_FLAG_SET(obj, flags)); }
+void            gstObjectFlagUnset      (GstObject * obj, guint32 flags) { (GST_OBJECT_FLAG_UNSET(obj, flags)); }
 
 /* Element utilities */
 
-GstTocSetter *  toTocSetter (GstElement * elem) { return GST_TOC_SETTER(elem); }
-GstTagSetter *  toTagSetter (GstElement *elem)  { return GST_TAG_SETTER(elem); }
+gboolean        gstElementIsURIHandler  (GstElement * elem) { return (GST_IS_URI_HANDLER(elem)); }
+GstTocSetter *  toTocSetter             (GstElement * elem) { return GST_TOC_SETTER(elem); }
+GstTagSetter *  toTagSetter             (GstElement *elem)  { return GST_TAG_SETTER(elem); }
 
 /* Sample Utilities */
 

--- a/gst/gst.go.h
+++ b/gst/gst.go.h
@@ -123,13 +123,15 @@ extern GstTagList *     makeTagListWritable   (GstTagList * tagList);
 
 /* Object Utilities */
 
-extern gboolean        gstElementIsURIHandler  (GstElement * elem);
-extern gboolean        gstObjectFlagIsSet      (GstObject * obj, GstElementFlags flags);
+extern gboolean        gstObjectFlagIsSet      (GstObject * obj, guint32 flags);
+extern void            gstObjectFlagSet        (GstObject * obj, guint32 flags);
+extern void            gstObjectFlagUnset      (GstObject * obj, guint32 flags);
 
 /* Element utilities */
 
-extern GstTocSetter *  toTocSetter (GstElement * elem);
-extern GstTagSetter *  toTagSetter (GstElement *elem);
+extern gboolean        gstElementIsURIHandler  (GstElement * elem);
+extern GstTocSetter *  toTocSetter             (GstElement * elem);
+extern GstTagSetter *  toTagSetter             (GstElement *elem);
 
 
 /* Misc */

--- a/gst/gst_element.go
+++ b/gst/gst_element.go
@@ -176,8 +176,8 @@ func (e *Element) CallAsync(f func()) {
 }
 
 // PostMessage posts a message on the element's bus
-// Takes ownership of the message so need to ref it before feeding it forward
 func (e *Element) PostMessage(message *Message) bool {
+	// gst_element_post_message takes ownership of the message so need to ref it before feeding it forward
 	return gobool(C.gst_element_post_message(e.Instance(), message.Ref().Instance()))
 }
 

--- a/gst/gst_element.go
+++ b/gst/gst_element.go
@@ -405,8 +405,21 @@ func (e *Element) GetStaticPad(name string) *Pad {
 }
 
 // Has returns true if this element has the given flags.
+// Non MT safe
 func (e *Element) Has(flags ElementFlags) bool {
-	return gobool(C.gstObjectFlagIsSet(C.toGstObject(e.Unsafe()), C.GstElementFlags(flags)))
+	return e.hasFlags(uint32(flags))
+}
+
+// Set element flags
+// Non MT safe
+func (e *Element) SetFlags(flags ElementFlags) {
+	e.setFlags(uint32(flags))
+}
+
+// Unset element flags
+// Non MT safe
+func (e *Element) UnsetFlags(flags ElementFlags) {
+	e.unsetFlags(uint32(flags))
 }
 
 // IsURIHandler returns true if this element can handle URIs.

--- a/gst/gst_element.go
+++ b/gst/gst_element.go
@@ -175,6 +175,12 @@ func (e *Element) CallAsync(f func()) {
 	)
 }
 
+// PostMessage posts a message on the element's bus
+// Takes ownership of the message so need to ref it before feeding it forward
+func (e *Element) PostMessage(message *Message) bool {
+	return gobool(C.gst_element_post_message(e.Instance(), message.Ref().Instance()))
+}
+
 // ChangeState performs the given transition on this element.
 func (e *Element) ChangeState(transition StateChange) StateChangeReturn {
 	return StateChangeReturn(C.gst_element_change_state(e.Instance(), C.GstStateChange(transition)))

--- a/gst/gst_message_constructors.go
+++ b/gst/gst_message_constructors.go
@@ -14,13 +14,21 @@ type GstObjectHolder interface {
 	GstObject() *C.GstObject
 }
 
+func getMessageSourceObj(src GstObjectHolder) *C.GstObject {
+	if src == nil {
+		return nil
+	}
+
+	return src.GstObject()
+}
+
 // NewApplicationMessage creates a new application-typed message. GStreamer will never
 // create these messages; they are a gift from them to you. Enjoy.
 //
 // The source of all message constructors must be a valid Object or descendant, specifically
 // one created from the go runtime. If not the message returned will be nil.
 func NewApplicationMessage(src GstObjectHolder, structure *Structure) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -32,7 +40,7 @@ func NewApplicationMessage(src GstObjectHolder, structure *Structure) *Message {
 // A value less than 0 for runningTime means that the element has no clock interaction and thus doesn't
 // care about the running time of the pipeline.
 func NewAsyncDoneMessage(src GstObjectHolder, runningTime ClockTime) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -45,7 +53,7 @@ func NewAsyncDoneMessage(src GstObjectHolder, runningTime ClockTime) *Message {
 
 // NewAsyncStartMessage returns a message that is posted by elements when they start an ASYNC state change.
 func NewAsyncStartMessage(src GstObjectHolder) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -60,7 +68,7 @@ func NewAsyncStartMessage(src GstObjectHolder) *Message {
 // may only set the pipeline to PLAYING after receiving a message with percent set to 100, which can happen after the pipeline
 // completed prerolling.
 func NewBufferingMessage(src GstObjectHolder, percent int) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -72,7 +80,7 @@ func NewBufferingMessage(src GstObjectHolder, percent int) *Message {
 // If this message is posted by the pipeline, the pipeline will select a new clock again when it goes to PLAYING. It might
 // therefore be needed to set the pipeline to PAUSED and PLAYING again.
 func NewClockLostMessage(src GstObjectHolder, clock *Clock) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -84,7 +92,7 @@ func NewClockLostMessage(src GstObjectHolder, clock *Clock) *Message {
 //
 // This message is mainly used internally to manage the clock selection.
 func NewClockProvideMessage(src GstObjectHolder, clock *Clock, ready bool) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -94,7 +102,7 @@ func NewClockProvideMessage(src GstObjectHolder, clock *Clock, ready bool) *Mess
 // NewCustomMessage creates a new custom-typed message. This can be used for anything not handled by other message-specific
 // functions to pass a message to the app. The structure field can be nil.
 func NewCustomMessage(src GstObjectHolder, msgType MessageType, structure *Structure) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -107,7 +115,7 @@ func NewCustomMessage(src GstObjectHolder, msgType MessageType, structure *Struc
 // NewDeviceAddedMessage creates a new device-added message. The device-added message is produced by a DeviceProvider or a DeviceMonitor.
 // They announce the appearance of monitored devices.
 func NewDeviceAddedMessage(src GstObjectHolder, device *Device) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -117,7 +125,7 @@ func NewDeviceAddedMessage(src GstObjectHolder, device *Device) *Message {
 // NewDeviceChangedMessage creates a new device-changed message. The device-changed message is produced by a DeviceProvider or a DeviceMonitor.
 // They announce that a device properties has changed and device represent the new modified version of changed_device.
 func NewDeviceChangedMessage(src GstObjectHolder, device, changedDevice *Device) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -127,7 +135,7 @@ func NewDeviceChangedMessage(src GstObjectHolder, device, changedDevice *Device)
 // NewDeviceRemovedMessage creates a new device-removed message. The device-removed message is produced by a DeviceProvider or a DeviceMonitor.
 // They announce the disappearance of monitored devices.
 func NewDeviceRemovedMessage(src GstObjectHolder, device *Device) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -137,7 +145,7 @@ func NewDeviceRemovedMessage(src GstObjectHolder, device *Device) *Message {
 // NewDurationChangedMessage creates a new duration changed message. This message is posted by elements that know the duration of a
 // stream when the duration changes. This message is received by bins and is used to calculate the total duration of a pipeline.
 func NewDurationChangedMessage(src GstObjectHolder) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -148,7 +156,7 @@ func NewDurationChangedMessage(src GstObjectHolder) *Message {
 // element to an application, for example "the firewire cable was unplugged". The format of the message should be documented in the
 // element's documentation. The structure field can be nil.
 func NewElementMessage(src GstObjectHolder, structure *Structure) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -161,7 +169,7 @@ func NewElementMessage(src GstObjectHolder, structure *Structure) *Message {
 // NewEOSMessage creates a new eos message. This message is generated and posted in the sink elements of a Bin. The bin will only forward
 // the EOS message to the application if all sinks have posted an EOS message.
 func NewEOSMessage(src GstObjectHolder) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -172,7 +180,7 @@ func NewEOSMessage(src GstObjectHolder) *Message {
 // occurred. The pipeline will probably (partially) stop. The application receiving this message should stop the pipeline.
 // Structure can be nil to not add a structure to the message.
 func NewErrorMessage(src GstObjectHolder, err error, debugStr string, structure *Structure) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -203,7 +211,7 @@ func NewErrorMessage(src GstObjectHolder, err error, debugStr string, structure 
 
 // NewHaveContextMessage creates a message that is posted when an element has a new local Context.
 func NewHaveContextMessage(src GstObjectHolder, ctx *Context) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -215,7 +223,7 @@ func NewHaveContextMessage(src GstObjectHolder, ctx *Context) *Message {
 
 // NewInfoMessage creates a new info message. Structure can be nil.
 func NewInfoMessage(src GstObjectHolder, msg string, debugStr string, structure *Structure) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -246,7 +254,7 @@ func NewInfoMessage(src GstObjectHolder, msg string, debugStr string, structure 
 
 // NewLatencyMessage creates a message that can be posted by elements when their latency requirements have changed.
 func NewLatencyMessage(src GstObjectHolder) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -255,7 +263,7 @@ func NewLatencyMessage(src GstObjectHolder) *Message {
 
 // NewNeedContextMessage creates a message that is posted when an element needs a specific Context.
 func NewNeedContextMessage(src GstObjectHolder, ctxType string) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -265,7 +273,7 @@ func NewNeedContextMessage(src GstObjectHolder, ctxType string) *Message {
 
 // NewNewClockMessage creates a new clock message. This message is posted whenever the pipeline selects a new clock for the pipeline.
 func NewNewClockMessage(src GstObjectHolder, clock *Clock) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -276,7 +284,7 @@ func NewNewClockMessage(src GstObjectHolder, clock *Clock) *Message {
 //
 // Code contains a well defined string describing the action. Text should contain a user visible string detailing the current action.
 func NewProgressMessage(src GstObjectHolder, progressType ProgressType, code, text string) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -288,7 +296,7 @@ func NewProgressMessage(src GstObjectHolder, progressType ProgressType, code, te
 // NewPropertyNotifyMessage creates a new message notifying an object's properties have changed. If the
 // source OR the value cannot be coereced to C types, the function will return nil.
 func NewPropertyNotifyMessage(src GstObjectHolder, propName string, val interface{}) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -313,7 +321,7 @@ func NewPropertyNotifyMessage(src GstObjectHolder, propName string, val interfac
 // running_time, stream_time, timestamp, duration should be set to the respective running-time, stream-time, timestamp and duration of the (dropped) buffer
 // that generated the QoS event. Values can be left to less than zero when unknown.
 func NewQoSMessage(src GstObjectHolder, live bool, runningTime, streamTime, timestamp, duration uint64) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -343,7 +351,7 @@ func NewQoSMessage(src GstObjectHolder, live bool, runningTime, streamTime, time
 //
 // The specified location string is copied. However, ownership over the tag list and structure are transferred to the message.
 func NewRedirectMessage(src GstObjectHolder, location string, tagList *TagList, entryStructure *Structure) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -389,7 +397,7 @@ func (m *Message) AddRedirectEntry(location string, tagList *TagList, entryStruc
 // NewRequestStateMessage creates a message that can be posted by elements when they want to have their state changed.
 // A typical use case would be an audio server that wants to pause the pipeline because a higher priority stream is being played.
 func NewRequestStateMessage(src GstObjectHolder, state State) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -398,7 +406,7 @@ func NewRequestStateMessage(src GstObjectHolder, state State) *Message {
 
 // NewResetTimeMessage creates a message that is posted when the pipeline running-time should be reset to running_time, like after a flushing seek.
 func NewResetTimeMessage(src GstObjectHolder, runningTime ClockTime) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -408,7 +416,7 @@ func NewResetTimeMessage(src GstObjectHolder, runningTime ClockTime) *Message {
 // NewSegmentDoneMessage creates a new segment done message. This message is posted by elements that finish playback of a segment as a result of a
 // segment seek. This message is received by the application after all elements that posted a segment_start have posted the segment_done.
 func NewSegmentDoneMessage(src GstObjectHolder, format Format, position int64) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -422,7 +430,7 @@ func NewSegmentDoneMessage(src GstObjectHolder, format Format, position int64) *
 // NewSegmentStartMessage creates a new segment message. This message is posted by elements that start playback of a segment as a result of a segment seek.
 // This message is not received by the application but is used for maintenance reasons in container elements.
 func NewSegmentStartMessage(src GstObjectHolder, format Format, position int64) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -435,7 +443,7 @@ func NewSegmentStartMessage(src GstObjectHolder, format Format, position int64) 
 
 // NewStateChangedMessage creates a state change message. This message is posted whenever an element changed its state.
 func NewStateChangedMessage(src GstObjectHolder, oldState, newState, pendingState State) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -448,7 +456,7 @@ func NewStateChangedMessage(src GstObjectHolder, oldState, newState, pendingStat
 // NewStateDirtyMessage creates a state dirty message. This message is posted whenever an element changed its state asynchronously
 // and is used internally to update the states of container objects.
 func NewStateDirtyMessage(src GstObjectHolder) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -460,7 +468,7 @@ func NewStateDirtyMessage(src GstObjectHolder) *Message {
 //
 // Duration will contain the amount of time of the stepped amount of media in format format.
 func NewStepDoneMessage(src GstObjectHolder, format Format, amount uint64, rate float64, flush, intermediate bool, duration uint64, eos bool) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -483,7 +491,7 @@ func NewStepDoneMessage(src GstObjectHolder, format Format, amount uint64, rate 
 // Active is set to TRUE when the element has activated the step operation and is now ready to start executing the step in the streaming thread.
 // After this message is emitted, the application can queue a new step operation in the element.
 func NewStepStartMessage(src GstObjectHolder, active bool, format Format, amount uint64, rate float64, flush, intermediate bool) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -500,7 +508,7 @@ func NewStepStartMessage(src GstObjectHolder, active bool, format Format, amount
 
 // NewStreamCollectionMessage creates a new stream-collection message. The message is used to announce new StreamCollections.
 func NewStreamCollectionMessage(src GstObjectHolder, collection *StreamCollection) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -510,7 +518,7 @@ func NewStreamCollectionMessage(src GstObjectHolder, collection *StreamCollectio
 // NewStreamStartMessage creates a new stream_start message. This message is generated and posted in the sink elements of a Bin.
 // The bin will only forward the StreamStart message to the application if all sinks have posted a StreamStart message.
 func NewStreamStartMessage(src GstObjectHolder) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -520,7 +528,7 @@ func NewStreamStartMessage(src GstObjectHolder) *Message {
 // NewStreamStatusMessage creates a new stream status message. This message is posted when a streaming thread is created/destroyed or
 // when the state changed.
 func NewStreamStatusMessage(src GstObjectHolder, stType StreamStatusType, owner *Element) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -534,7 +542,7 @@ func NewStreamStatusMessage(src GstObjectHolder, stType StreamStatusType, owner 
 //
 // Users of this constructor can add the selected streams with StreamsSelectedAdd.
 func NewStreamSelectedMessage(src GstObjectHolder, collection *StreamCollection) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -565,7 +573,7 @@ func (m *Message) StreamsSelectedGetStream(index uint) *Stream {
 //
 // Src should be the sinkpad that unlinked or linked.
 func NewStructureChangeMessage(src GstObjectHolder, chgType StructureChangeType, owner *Element, busy bool) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -579,7 +587,7 @@ func NewStructureChangeMessage(src GstObjectHolder, chgType StructureChangeType,
 
 // NewTagMessage creates a new tag message. The message will take ownership of the tag list. The message is posted by elements that discovered a new taglist.
 func NewTagMessage(src GstObjectHolder, tagList *TagList) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -588,7 +596,7 @@ func NewTagMessage(src GstObjectHolder, tagList *TagList) *Message {
 
 // NewTOCMessage creates a new TOC message. The message is posted by elements that discovered or updated a TOC.
 func NewTOCMessage(src GstObjectHolder, toc *TOC, updated bool) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}
@@ -601,7 +609,7 @@ func NewTOCMessage(src GstObjectHolder, toc *TOC, updated bool) *Message {
 
 // NewWarningMessage creates a new warning message. Structure can be nil.
 func NewWarningMessage(src GstObjectHolder, msg string, debugStr string, structure *Structure) *Message {
-	srcObj := src.GstObject()
+	srcObj := getMessageSourceObj(src)
 	if srcObj == nil {
 		return nil
 	}

--- a/gst/gst_message_constructors.go
+++ b/gst/gst_message_constructors.go
@@ -8,16 +8,8 @@ import (
 	"github.com/go-gst/go-glib/glib"
 )
 
-type Unsafer interface {
-	Unsafe() unsafe.Pointer
-}
-
-func getMessageSourceObj(src Unsafer) *C.GstObject {
-	if src == nil {
-		return nil
-	}
-
-	return C.toGstObject(src.Unsafe())
+type GstObjectHolder interface {
+	GstObject() *C.GstObject
 }
 
 // NewApplicationMessage creates a new application-typed message. GStreamer will never
@@ -25,8 +17,8 @@ func getMessageSourceObj(src Unsafer) *C.GstObject {
 //
 // The source of all message constructors must be a valid Object or descendant, specifically
 // one created from the go runtime. If not the message returned will be nil.
-func NewApplicationMessage(src Unsafer, structure *Structure) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewApplicationMessage(src GstObjectHolder, structure *Structure) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -37,8 +29,8 @@ func NewApplicationMessage(src Unsafer, structure *Structure) *Message {
 // RunningTime contains the time of the desired running time when this elements goes to PLAYING.
 // A value less than 0 for runningTime means that the element has no clock interaction and thus doesn't
 // care about the running time of the pipeline.
-func NewAsyncDoneMessage(src Unsafer, runningTime ClockTime) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewAsyncDoneMessage(src GstObjectHolder, runningTime ClockTime) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -50,8 +42,8 @@ func NewAsyncDoneMessage(src Unsafer, runningTime ClockTime) *Message {
 }
 
 // NewAsyncStartMessage returns a message that is posted by elements when they start an ASYNC state change.
-func NewAsyncStartMessage(src Unsafer) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewAsyncStartMessage(src GstObjectHolder) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -65,8 +57,8 @@ func NewAsyncStartMessage(src Unsafer) *Message {
 // pipeline (back) to PLAYING. The application must be prepared to receive BUFFERING messages in the PREROLLING state and
 // may only set the pipeline to PLAYING after receiving a message with percent set to 100, which can happen after the pipeline
 // completed prerolling.
-func NewBufferingMessage(src Unsafer, percent int) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewBufferingMessage(src GstObjectHolder, percent int) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -77,8 +69,8 @@ func NewBufferingMessage(src Unsafer, percent int) *Message {
 //
 // If this message is posted by the pipeline, the pipeline will select a new clock again when it goes to PLAYING. It might
 // therefore be needed to set the pipeline to PAUSED and PLAYING again.
-func NewClockLostMessage(src Unsafer, clock *Clock) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewClockLostMessage(src GstObjectHolder, clock *Clock) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -89,8 +81,8 @@ func NewClockLostMessage(src Unsafer, clock *Clock) *Message {
 // clock or lost its ability to provide a clock (maybe because it paused or became EOS).
 //
 // This message is mainly used internally to manage the clock selection.
-func NewClockProvideMessage(src Unsafer, clock *Clock, ready bool) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewClockProvideMessage(src GstObjectHolder, clock *Clock, ready bool) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -99,8 +91,8 @@ func NewClockProvideMessage(src Unsafer, clock *Clock, ready bool) *Message {
 
 // NewCustomMessage creates a new custom-typed message. This can be used for anything not handled by other message-specific
 // functions to pass a message to the app. The structure field can be nil.
-func NewCustomMessage(src Unsafer, msgType MessageType, structure *Structure) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewCustomMessage(src GstObjectHolder, msgType MessageType, structure *Structure) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -112,8 +104,8 @@ func NewCustomMessage(src Unsafer, msgType MessageType, structure *Structure) *M
 
 // NewDeviceAddedMessage creates a new device-added message. The device-added message is produced by a DeviceProvider or a DeviceMonitor.
 // They announce the appearance of monitored devices.
-func NewDeviceAddedMessage(src Unsafer, device *Device) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewDeviceAddedMessage(src GstObjectHolder, device *Device) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -122,8 +114,8 @@ func NewDeviceAddedMessage(src Unsafer, device *Device) *Message {
 
 // NewDeviceChangedMessage creates a new device-changed message. The device-changed message is produced by a DeviceProvider or a DeviceMonitor.
 // They announce that a device properties has changed and device represent the new modified version of changed_device.
-func NewDeviceChangedMessage(src Unsafer, device, changedDevice *Device) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewDeviceChangedMessage(src GstObjectHolder, device, changedDevice *Device) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -132,8 +124,8 @@ func NewDeviceChangedMessage(src Unsafer, device, changedDevice *Device) *Messag
 
 // NewDeviceRemovedMessage creates a new device-removed message. The device-removed message is produced by a DeviceProvider or a DeviceMonitor.
 // They announce the disappearance of monitored devices.
-func NewDeviceRemovedMessage(src Unsafer, device *Device) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewDeviceRemovedMessage(src GstObjectHolder, device *Device) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -142,8 +134,8 @@ func NewDeviceRemovedMessage(src Unsafer, device *Device) *Message {
 
 // NewDurationChangedMessage creates a new duration changed message. This message is posted by elements that know the duration of a
 // stream when the duration changes. This message is received by bins and is used to calculate the total duration of a pipeline.
-func NewDurationChangedMessage(src Unsafer) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewDurationChangedMessage(src GstObjectHolder) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -153,8 +145,8 @@ func NewDurationChangedMessage(src Unsafer) *Message {
 // NewElementMessage creates a new element-specific message. This is meant as a generic way of allowing one-way communication from an
 // element to an application, for example "the firewire cable was unplugged". The format of the message should be documented in the
 // element's documentation. The structure field can be nil.
-func NewElementMessage(src Unsafer, structure *Structure) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewElementMessage(src GstObjectHolder, structure *Structure) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -166,8 +158,8 @@ func NewElementMessage(src Unsafer, structure *Structure) *Message {
 
 // NewEOSMessage creates a new eos message. This message is generated and posted in the sink elements of a Bin. The bin will only forward
 // the EOS message to the application if all sinks have posted an EOS message.
-func NewEOSMessage(src Unsafer) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewEOSMessage(src GstObjectHolder) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -177,8 +169,8 @@ func NewEOSMessage(src Unsafer) *Message {
 // NewErrorMessage creates a new error message. The message will copy error and debug. This message is posted by element when a fatal event
 // occurred. The pipeline will probably (partially) stop. The application receiving this message should stop the pipeline.
 // Structure can be nil to not add a structure to the message.
-func NewErrorMessage(src Unsafer, err error, debugStr string, structure *Structure) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewErrorMessage(src GstObjectHolder, err error, debugStr string, structure *Structure) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -208,8 +200,8 @@ func NewErrorMessage(src Unsafer, err error, debugStr string, structure *Structu
 }
 
 // NewHaveContextMessage creates a message that is posted when an element has a new local Context.
-func NewHaveContextMessage(src Unsafer, ctx *Context) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewHaveContextMessage(src GstObjectHolder, ctx *Context) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -220,8 +212,8 @@ func NewHaveContextMessage(src Unsafer, ctx *Context) *Message {
 }
 
 // NewInfoMessage creates a new info message. Structure can be nil.
-func NewInfoMessage(src Unsafer, msg string, debugStr string, structure *Structure) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewInfoMessage(src GstObjectHolder, msg string, debugStr string, structure *Structure) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -251,8 +243,8 @@ func NewInfoMessage(src Unsafer, msg string, debugStr string, structure *Structu
 }
 
 // NewLatencyMessage creates a message that can be posted by elements when their latency requirements have changed.
-func NewLatencyMessage(src Unsafer) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewLatencyMessage(src GstObjectHolder) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -260,8 +252,8 @@ func NewLatencyMessage(src Unsafer) *Message {
 }
 
 // NewNeedContextMessage creates a message that is posted when an element needs a specific Context.
-func NewNeedContextMessage(src Unsafer, ctxType string) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewNeedContextMessage(src GstObjectHolder, ctxType string) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -270,8 +262,8 @@ func NewNeedContextMessage(src Unsafer, ctxType string) *Message {
 }
 
 // NewNewClockMessage creates a new clock message. This message is posted whenever the pipeline selects a new clock for the pipeline.
-func NewNewClockMessage(src Unsafer, clock *Clock) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewNewClockMessage(src GstObjectHolder, clock *Clock) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -281,8 +273,8 @@ func NewNewClockMessage(src Unsafer, clock *Clock) *Message {
 // NewProgressMessage creates messages that are posted by elements when they use an asynchronous task to perform actions triggered by a state change.
 //
 // Code contains a well defined string describing the action. Text should contain a user visible string detailing the current action.
-func NewProgressMessage(src Unsafer, progressType ProgressType, code, text string) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewProgressMessage(src GstObjectHolder, progressType ProgressType, code, text string) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -293,8 +285,8 @@ func NewProgressMessage(src Unsafer, progressType ProgressType, code, text strin
 
 // NewPropertyNotifyMessage creates a new message notifying an object's properties have changed. If the
 // source OR the value cannot be coereced to C types, the function will return nil.
-func NewPropertyNotifyMessage(src Unsafer, propName string, val interface{}) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewPropertyNotifyMessage(src GstObjectHolder, propName string, val interface{}) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -318,8 +310,8 @@ func NewPropertyNotifyMessage(src Unsafer, propName string, val interface{}) *Me
 //
 // running_time, stream_time, timestamp, duration should be set to the respective running-time, stream-time, timestamp and duration of the (dropped) buffer
 // that generated the QoS event. Values can be left to less than zero when unknown.
-func NewQoSMessage(src Unsafer, live bool, runningTime, streamTime, timestamp, duration uint64) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewQoSMessage(src GstObjectHolder, live bool, runningTime, streamTime, timestamp, duration uint64) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -348,8 +340,8 @@ func NewQoSMessage(src Unsafer, live bool, runningTime, streamTime, timestamp, d
 // an entry that is "best" for them. One example would be a recipient that scans the entries for the one with the highest bitrate tag.
 //
 // The specified location string is copied. However, ownership over the tag list and structure are transferred to the message.
-func NewRedirectMessage(src Unsafer, location string, tagList *TagList, entryStructure *Structure) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewRedirectMessage(src GstObjectHolder, location string, tagList *TagList, entryStructure *Structure) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -394,8 +386,8 @@ func (m *Message) AddRedirectEntry(location string, tagList *TagList, entryStruc
 
 // NewRequestStateMessage creates a message that can be posted by elements when they want to have their state changed.
 // A typical use case would be an audio server that wants to pause the pipeline because a higher priority stream is being played.
-func NewRequestStateMessage(src Unsafer, state State) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewRequestStateMessage(src GstObjectHolder, state State) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -403,8 +395,8 @@ func NewRequestStateMessage(src Unsafer, state State) *Message {
 }
 
 // NewResetTimeMessage creates a message that is posted when the pipeline running-time should be reset to running_time, like after a flushing seek.
-func NewResetTimeMessage(src Unsafer, runningTime ClockTime) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewResetTimeMessage(src GstObjectHolder, runningTime ClockTime) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -413,8 +405,8 @@ func NewResetTimeMessage(src Unsafer, runningTime ClockTime) *Message {
 
 // NewSegmentDoneMessage creates a new segment done message. This message is posted by elements that finish playback of a segment as a result of a
 // segment seek. This message is received by the application after all elements that posted a segment_start have posted the segment_done.
-func NewSegmentDoneMessage(src Unsafer, format Format, position int64) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewSegmentDoneMessage(src GstObjectHolder, format Format, position int64) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -427,8 +419,8 @@ func NewSegmentDoneMessage(src Unsafer, format Format, position int64) *Message 
 
 // NewSegmentStartMessage creates a new segment message. This message is posted by elements that start playback of a segment as a result of a segment seek.
 // This message is not received by the application but is used for maintenance reasons in container elements.
-func NewSegmentStartMessage(src Unsafer, format Format, position int64) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewSegmentStartMessage(src GstObjectHolder, format Format, position int64) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -440,8 +432,8 @@ func NewSegmentStartMessage(src Unsafer, format Format, position int64) *Message
 }
 
 // NewStateChangedMessage creates a state change message. This message is posted whenever an element changed its state.
-func NewStateChangedMessage(src Unsafer, oldState, newState, pendingState State) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewStateChangedMessage(src GstObjectHolder, oldState, newState, pendingState State) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -453,8 +445,8 @@ func NewStateChangedMessage(src Unsafer, oldState, newState, pendingState State)
 
 // NewStateDirtyMessage creates a state dirty message. This message is posted whenever an element changed its state asynchronously
 // and is used internally to update the states of container objects.
-func NewStateDirtyMessage(src Unsafer) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewStateDirtyMessage(src GstObjectHolder) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -465,8 +457,8 @@ func NewStateDirtyMessage(src Unsafer) *Message {
 // complete step operation.
 //
 // Duration will contain the amount of time of the stepped amount of media in format format.
-func NewStepDoneMessage(src Unsafer, format Format, amount uint64, rate float64, flush, intermediate bool, duration uint64, eos bool) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewStepDoneMessage(src GstObjectHolder, format Format, amount uint64, rate float64, flush, intermediate bool, duration uint64, eos bool) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -488,8 +480,8 @@ func NewStepDoneMessage(src Unsafer, format Format, amount uint64, rate float64,
 //
 // Active is set to TRUE when the element has activated the step operation and is now ready to start executing the step in the streaming thread.
 // After this message is emitted, the application can queue a new step operation in the element.
-func NewStepStartMessage(src Unsafer, active bool, format Format, amount uint64, rate float64, flush, intermediate bool) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewStepStartMessage(src GstObjectHolder, active bool, format Format, amount uint64, rate float64, flush, intermediate bool) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -505,8 +497,8 @@ func NewStepStartMessage(src Unsafer, active bool, format Format, amount uint64,
 }
 
 // NewStreamCollectionMessage creates a new stream-collection message. The message is used to announce new StreamCollections.
-func NewStreamCollectionMessage(src Unsafer, collection *StreamCollection) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewStreamCollectionMessage(src GstObjectHolder, collection *StreamCollection) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -515,8 +507,8 @@ func NewStreamCollectionMessage(src Unsafer, collection *StreamCollection) *Mess
 
 // NewStreamStartMessage creates a new stream_start message. This message is generated and posted in the sink elements of a Bin.
 // The bin will only forward the StreamStart message to the application if all sinks have posted a StreamStart message.
-func NewStreamStartMessage(src Unsafer) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewStreamStartMessage(src GstObjectHolder) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -525,8 +517,8 @@ func NewStreamStartMessage(src Unsafer) *Message {
 
 // NewStreamStatusMessage creates a new stream status message. This message is posted when a streaming thread is created/destroyed or
 // when the state changed.
-func NewStreamStatusMessage(src Unsafer, stType StreamStatusType, owner *Element) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewStreamStatusMessage(src GstObjectHolder, stType StreamStatusType, owner *Element) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -539,8 +531,8 @@ func NewStreamStatusMessage(src Unsafer, stType StreamStatusType, owner *Element
 // The message also contains the StreamCollection to which the various streams belong to.
 //
 // Users of this constructor can add the selected streams with StreamsSelectedAdd.
-func NewStreamSelectedMessage(src Unsafer, collection *StreamCollection) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewStreamSelectedMessage(src GstObjectHolder, collection *StreamCollection) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -570,8 +562,8 @@ func (m *Message) StreamsSelectedGetStream(index uint) *Stream {
 // of being changed, for example when pads are linked or unlinked.
 //
 // Src should be the sinkpad that unlinked or linked.
-func NewStructureChangeMessage(src Unsafer, chgType StructureChangeType, owner *Element, busy bool) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewStructureChangeMessage(src GstObjectHolder, chgType StructureChangeType, owner *Element, busy bool) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -584,8 +576,8 @@ func NewStructureChangeMessage(src Unsafer, chgType StructureChangeType, owner *
 }
 
 // NewTagMessage creates a new tag message. The message will take ownership of the tag list. The message is posted by elements that discovered a new taglist.
-func NewTagMessage(src Unsafer, tagList *TagList) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewTagMessage(src GstObjectHolder, tagList *TagList) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -593,8 +585,8 @@ func NewTagMessage(src Unsafer, tagList *TagList) *Message {
 }
 
 // NewTOCMessage creates a new TOC message. The message is posted by elements that discovered or updated a TOC.
-func NewTOCMessage(src Unsafer, toc *TOC, updated bool) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewTOCMessage(src GstObjectHolder, toc *TOC, updated bool) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}
@@ -606,8 +598,8 @@ func NewTOCMessage(src Unsafer, toc *TOC, updated bool) *Message {
 }
 
 // NewWarningMessage creates a new warning message. Structure can be nil.
-func NewWarningMessage(src Unsafer, msg string, debugStr string, structure *Structure) *Message {
-	srcObj := getMessageSourceObj(src)
+func NewWarningMessage(src GstObjectHolder, msg string, debugStr string, structure *Structure) *Message {
+	srcObj := src.GstObject()
 	if srcObj == nil {
 		return nil
 	}

--- a/gst/gst_message_constructors.go
+++ b/gst/gst_message_constructors.go
@@ -8,6 +8,8 @@ import (
 	"github.com/go-gst/go-glib/glib"
 )
 
+// GstObjectHolder interface is used as a go representation of the GLib check
+// for an input type to be derived from the GstObject.
 type GstObjectHolder interface {
 	GstObject() *C.GstObject
 }

--- a/gst/gst_object.go
+++ b/gst/gst_object.go
@@ -97,3 +97,22 @@ func (o *Object) Unref() {
 func (o *Object) AddControlBinding(binding *ControlBinding) {
 	C.gst_object_add_control_binding(o.Instance(), binding.Instance())
 }
+
+// TODO: Consider wrapping GstObject GST_OBJECT_LOCK/GST_OBJECT_UNLOCK functionality
+// due to following flags related functionality is based on a regular uint32 field
+// and is not considered thread safe
+
+// Has returns true if this GstObject has the given flags.
+func (o *Object) hasFlags(flags uint32) bool {
+	return gobool(C.gstObjectFlagIsSet(o.Instance(), C.guint32(flags)))
+}
+
+// SetFlags sets the flags
+func (o *Object) setFlags(flags uint32) {
+	C.gstObjectFlagSet(o.Instance(), C.guint32(flags))
+}
+
+// SetFlags unsets the flags
+func (o *Object) unsetFlags(flags uint32) {
+	C.gstObjectFlagUnset(o.Instance(), C.guint32(flags))
+}

--- a/gst/gst_pad.go
+++ b/gst/gst_pad.go
@@ -1075,6 +1075,24 @@ func (p *Pad) ToGValue() (*glib.Value, error) {
 	return val, nil
 }
 
+// Has returns true if this pad has the given flags.
+// Non MT safe
+func (p *Pad) Has(flags PadFlags) bool {
+	return p.hasFlags(uint32(flags))
+}
+
+// Sets pad flags
+// Non MT safe
+func (p *Pad) SetFlags(flags PadFlags) {
+	p.setFlags(uint32(flags))
+}
+
+// Unsets pad flags
+// Non MT safe
+func (p *Pad) UnsetFlags(flags PadFlags) {
+	p.unsetFlags(uint32(flags))
+}
+
 // PadProbeInfo represents the info passed to a PadProbeCallback.
 type PadProbeInfo struct {
 	ptr *C.GstPadProbeInfo


### PR DESCRIPTION
* Added gst_element_post_message wrapper
* Added gst object flag set/unset function + their specializations for pad and element
* Changed interface{Unsafe()} casting to explicit interface requirement to improve usability of gst message constructors (It still looks pretty strange with all those Unsafe/Instance/(other semi-raw pointer getters) due to it's still the same pointer but so many different accessors to it)
* Removed redundant gst message ptr casting to avoid redundant text + unintentional cast possibility

Those led to an identity like plugin example which shows how to use async state changes.