### PR TITLE
sdp: add message media and media format accessors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-gst/go-gst
 
-go 1.22
+go 1.23
 
 require github.com/mattn/go-pointer v0.0.1
 

--- a/gst/gst_caps.go
+++ b/gst/gst_caps.go
@@ -267,7 +267,15 @@ func (c *Caps) GetStructureAt(idx int) *Structure {
 	if st == nil {
 		return nil
 	}
-	return wrapStructure(st)
+	s := wrapStructure(st)
+
+	// we don't own the structure, so keep the caps alive until we
+	// don't need the structure anymore
+	runtime.SetFinalizer(s, func(_ *Structure) {
+		runtime.KeepAlive(c)
+	})
+
+	return s
 }
 
 // GetFeaturesAt returns the feature at the given index, or nil if none exists.

--- a/gst/gstsdp/media.go
+++ b/gst/gstsdp/media.go
@@ -1,0 +1,47 @@
+package gstsdp
+
+// #include "gst.go.h"
+import "C"
+import (
+	"errors"
+	"iter"
+	"unsafe"
+
+	"github.com/go-gst/go-gst/gst"
+)
+
+type Media struct {
+	ptr *C.GstSDPMedia
+}
+
+func (m *Media) FormatsLen() int {
+	return int(C.gst_sdp_media_formats_len(m.ptr))
+}
+
+func (m *Media) Format(idx int) string {
+	cstr := C.gst_sdp_media_get_format(m.ptr, C.guint(idx))
+
+	return C.GoString(cstr)
+}
+
+func (m *Media) Formats() iter.Seq2[int, string] {
+	return func(yield func(int, string) bool) {
+		for i := 0; i < m.FormatsLen(); i++ {
+			if !yield(i, m.Format(i)) {
+				return
+			}
+		}
+	}
+}
+
+var ErrCouldNotGetCaps = errors.New("could not get caps")
+
+func (m *Media) GetCaps(pt int) (*gst.Caps, error) {
+	ccaps := C.gst_sdp_media_get_caps_from_media(m.ptr, C.gint(pt))
+
+	if ccaps == nil {
+		return nil, ErrCouldNotGetCaps
+	}
+
+	return gst.FromGstCapsUnsafeFull(unsafe.Pointer(ccaps)), nil
+}

--- a/gst/gstsdp/message_test.go
+++ b/gst/gstsdp/message_test.go
@@ -1,0 +1,102 @@
+package gstsdp_test
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"testing"
+
+	"github.com/go-gst/go-gst/gst"
+	"github.com/go-gst/go-gst/gst/gstsdp"
+)
+
+func TestSessionDescription(t *testing.T) {
+	gst.Init(nil)
+
+	sdp, err := gstsdp.ParseSDPMessage(testmsg)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, media := range sdp.Medias() {
+		for _, f := range media.Formats() {
+			fmt.Printf("found format: %s\n", f)
+
+			pt, err := strconv.Atoi(f)
+
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			caps, err := media.GetCaps(pt)
+
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			fmt.Println(caps.String())
+
+			s := caps.GetStructureAt(0)
+
+			if s == nil {
+				continue
+			}
+
+			runtime.GC()
+
+			encname, err := s.GetValue("encoding-name")
+
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			fmt.Println(encname)
+		}
+	}
+}
+
+var testmsg = `
+v=0
+o=- 3546004397921447048 1596742744 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=fingerprint:sha-256 0F:74:31:25:CB:A2:13:EC:28:6F:6D:2C:61:FF:5D:C2:BC:B9:DB:3D:98:14:8D:1A:BB:EA:33:0C:A4:60:A8:8E
+a=group:BUNDLE 0 1
+m=audio 9 UDP/TLS/RTP/SAVPF 111
+c=IN IP4 0.0.0.0
+a=setup:active
+a=mid:0
+a=ice-ufrag:CsxzEWmoKpJyscFj
+a=ice-pwd:mktpbhgREmjEwUFSIJyPINPUhgDqJlSd
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:111 opus/48000/2
+a=fmtp:111 minptime=10;useinbandfec=1
+a=ssrc:350842737 cname:yvKPspsHcYcwGFTw
+a=ssrc:350842737 msid:yvKPspsHcYcwGFTw DfQnKjQQuwceLFdV
+a=ssrc:350842737 mslabel:yvKPspsHcYcwGFTw
+a=ssrc:350842737 label:DfQnKjQQuwceLFdV
+a=msid:yvKPspsHcYcwGFTw DfQnKjQQuwceLFdV
+a=sendrecv
+a=candidate:foundation 1 udp 2130706431 192.168.1.1 53165 typ host generation 0
+a=candidate:foundation 2 udp 2130706431 192.168.1.1 53165 typ host generation 0
+a=candidate:foundation 1 udp 1694498815 1.2.3.4 57336 typ srflx raddr 0.0.0.0 rport 57336 generation 0
+a=candidate:foundation 2 udp 1694498815 1.2.3.4 57336 typ srflx raddr 0.0.0.0 rport 57336 generation 0
+a=end-of-candidates
+m=video 9 UDP/TLS/RTP/SAVPF 96
+c=IN IP4 0.0.0.0
+a=setup:active
+a=mid:1
+a=ice-ufrag:CsxzEWmoKpJyscFj
+a=ice-pwd:mktpbhgREmjEwUFSIJyPINPUhgDqJlSd
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:96 VP8/90000
+a=ssrc:2180035812 cname:XHbOTNRFnLtesHwJ
+a=ssrc:2180035812 msid:XHbOTNRFnLtesHwJ JgtwEhBWNEiOnhuW
+a=ssrc:2180035812 mslabel:XHbOTNRFnLtesHwJ
+a=ssrc:2180035812 label:JgtwEhBWNEiOnhuW
+a=msid:XHbOTNRFnLtesHwJ JgtwEhBWNEiOnhuW
+a=sendrecv
+`


### PR DESCRIPTION
this also updates to go 1.23 since it is very useful to use the new `iter` package for the medias and formats