### PR TITLE
webrtc: fix nil deref marshal *SessionDescription

### DIFF
--- a/gst/gstwebrtc/session_description.go
+++ b/gst/gstwebrtc/session_description.go
@@ -104,7 +104,11 @@ func (sd *SessionDescription) ToGValue() (*glib.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	val.SetBoxed(unsafe.Pointer(sd.ptr))
+	var ptr *C.GstWebRTCSessionDescription
+	if sd != nil {
+		ptr = sd.ptr
+	}
+	val.SetBoxed(unsafe.Pointer(ptr))
 	return val, nil
 }
 


### PR DESCRIPTION
When the SessionDescription pointer is nil, ToGValue() will crash dereferencing the pointer. Fix this by avoiding the dereference.

The ability to marshal a NULL value is required for compatibility with other languages. This change has been tested with the custom signalling from gst-plugins-rs, in which a signaller may emit a `session-requested` signal with an optional offer SDP.