### PR TITLE
add pprof Profile to trace active pad probes

### DIFF
--- a/gst/cgo_exports.go
+++ b/gst/cgo_exports.go
@@ -189,6 +189,8 @@ func goGDestroyNotifyFunc(ptr C.gpointer) {
 //export goGDestroyNotifyFuncNoRun
 func goGDestroyNotifyFuncNoRun(ptr C.gpointer) {
 	gopointer.Unref(unsafe.Pointer(ptr))
+
+	padprobesProfile.Remove(unsafe.Pointer(ptr)) // no-op if it wasn't a pad probe
 }
 
 //export goCapsMapFunc

--- a/gst/gst_pad.go
+++ b/gst/gst_pad.go
@@ -197,6 +197,9 @@ type PadProbeCallback func(*Pad, *PadProbeInfo) PadProbeReturn
 // A probe ID is returned that can be used to remove the probe.
 func (p *Pad) AddProbe(mask PadProbeType, f PadProbeCallback) uint64 {
 	ptr := gopointer.Save(f)
+
+	padprobesProfile.Add(ptr, 1)
+
 	ret := C.gst_pad_add_probe(
 		p.Instance(),
 		C.GstPadProbeType(mask),

--- a/gst/trace.go
+++ b/gst/trace.go
@@ -1,0 +1,13 @@
+package gst
+
+import "runtime/pprof"
+
+var padprobesProfile *pprof.Profile
+
+func init() {
+	padprobes := "go-gst-active-pad-probes"
+	padprobesProfile = pprof.Lookup(padprobes)
+	if padprobesProfile == nil {
+		padprobesProfile = pprof.NewProfile(padprobes)
+	}
+}


### PR DESCRIPTION
see also https://github.com/go-gst/go-glib/pull/22

This PR implements the same pprof tracing for pad probes