### PR TITLE
add gst_debug_set_threshold_from_string

### DIFF
--- a/gst/gst_debug.go
+++ b/gst/gst_debug.go
@@ -38,6 +38,11 @@ void cgoResetLogFunction()
 	gst_debug_add_log_function(gst_debug_log_default, NULL, NULL);
 }
 
+void cgoDebugSetThresholdFromStringFunction(const gchar* args)
+{
+  gst_debug_set_threshold_from_string(args, TRUE);
+}
+
 */
 import "C"
 import (
@@ -248,4 +253,11 @@ func SetLogFunction(f LogFunction) {
 		C.cgoSetLogFunction()
 	}
 	customLogFunction = f
+}
+
+func DebugSetThresholdFromString(args string) {
+	_args := C.CString(args)
+	defer C.free(unsafe.Pointer(_args)) // Free C string memory
+
+	C.cgoDebugSetThresholdFromStringFunction(_args)
 }


### PR DESCRIPTION
in my case i needed to catch all logs i used setLogFunction already provided, but it wont catch all logs from the beggings so i figured out that i must add it before alongside wioth SetLogFunction gst.Init(nil),  however it does exists in the library, that why i added DebugSetThresholdFromString, i hope it helps for anybody who's looking for the same function