### PR TITLE
add SourceObject to GstMessage.

### DIFF
--- a/gst/gst_message.go
+++ b/gst/gst_message.go
@@ -59,8 +59,13 @@ func (m *Message) Copy() *Message {
 	return FromGstMessageUnsafeFull(unsafe.Pointer(newNative))
 }
 
-// Source returns the source of the message.
+// Source returns name of the source of the message.
 func (m *Message) Source() string { return C.GoString(m.Instance().src.name) }
+
+// Source returns object of the source of the message.
+func (m *Message) SourceObject() *Object {
+	return wrapObject(glib.Take(unsafe.Pointer(m.Instance().src)))
+}
 
 // Type returns the MessageType of the message.
 func (m *Message) Type() MessageType {


### PR DESCRIPTION
fixes #161

Although probably the correct solution would be to replace `Source() string` with `Source() *Object` as you could easily get name (and also parent of an object since 8fc1b481c98aeaa20bc49ad39c4bb0406a50144c). But I am not sure how much do you want to keep it backwards combatible, so I just added a new function.