### PR TITLE
Allow more flexible debug logging configuration

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -205,6 +205,9 @@ var Data = genmain.Data{
 					typesystem.IgnoreMatching("Sample.make_writable"),
 					typesystem.IgnoreMatching("TagList.is_writable"),
 					typesystem.IgnoreMatching("TagList.make_writable"),
+
+					// Manually implemented since https://github.com/go-gst/go-gst/pull/219:
+					typesystem.IgnoreMatching("debug_add_log_function"),
 				},
 			},
 			"GstAllocators-1": {

--- a/pkg/gst/gst.gen.go
+++ b/pkg/gst/gst.gen.go
@@ -38,7 +38,6 @@ import (
 // extern gboolean _goglib_gst1_StructureMapIdStrFunc(const GstIdStr*, GValue*, gpointer);
 // extern void _goglib_gst1_ElementCallAsyncFunc(GstElement*, gpointer);
 // extern void _goglib_gst1_IteratorForeachFunction(const GValue*, gpointer);
-// extern void _goglib_gst1_LogFunction(GstDebugCategory*, GstDebugLevel, const gchar*, const gchar*, gint, GObject*, GstDebugMessage*, gpointer);
 // extern void _goglib_gst1_TagForeachFunc(const GstTagList*, const gchar*, gpointer);
 // extern void _goglib_gst1_TaskFunction(gpointer);
 // extern void _goglib_gst1_TypeFindFunction(GstTypeFind*, gpointer);
@@ -7231,22 +7230,6 @@ type ElementCallAsyncFunc func(element Element)
 // 
 // see also https://gstreamer.freedesktop.org/documentation/gstreamer/gstelement.html#GstElementForeachPadFunc
 type ElementForeachPadFunc func(element Element, pad Pad) (goret bool)
-
-// DebugAddLogFunction wraps gst_debug_add_log_function
-// 
-// see also https://gstreamer.freedesktop.org/documentation/gstreamer
-func DebugAddLogFunction(fn LogFunction) {
-	var carg1 C.GstLogFunction // callback, scope: notified, closure: carg2, destroy: carg3
-	var carg2 C.gpointer       // implicit
-	var carg3 C.GDestroyNotify // implicit
-
-	carg1 = (*[0]byte)(C._goglib_gst1_LogFunction)
-	carg2 = C.gpointer(userdata.Register(fn))
-	carg3 = (C.GDestroyNotify)((*[0]byte)(C.destroyUserdata))
-
-	C.gst_debug_add_log_function(carg1, carg2, carg3)
-	runtime.KeepAlive(fn)
-}
 
 // DebugAddRingBufferLogger wraps gst_debug_add_ring_buffer_logger
 // 

--- a/pkg/gst/log_manual.go
+++ b/pkg/gst/log_manual.go
@@ -1,0 +1,61 @@
+package gst
+
+// #cgo pkg-config: gstreamer-1.0
+// #cgo CFLAGS: -Wno-deprecated-declarations
+// #include <gst/gst.h>
+// extern void _goglib_gst1_LogFunction(GstDebugCategory*, GstDebugLevel, const gchar*, const gchar*, gint, GObject*, GstDebugMessage*, gpointer);
+// extern void destroyUserdata(gpointer);
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/go-gst/go-glib/pkg/core/userdata"
+)
+
+// LogFunctionHandle is a handle returned by [DebugAddLogFunction] that can be used to remove the
+// log function later via [DebugRemoveLogFunction].
+type LogFunctionHandle unsafe.Pointer
+
+// DebugAddLogFunction wraps gst_debug_add_log_function.
+//
+// See https://gstreamer.freedesktop.org/documentation/gstreamer/gstinfo.html#gst_debug_add_log_function
+//
+// Returns a [LogFunctionHandle] that can be passed to [DebugRemoveLogFunction] to remove the log
+// function later.
+func DebugAddLogFunction(fn LogFunction) LogFunctionHandle {
+	ptr := userdata.Register(fn)
+
+	C.gst_debug_add_log_function(
+		(*[0]byte)(C._goglib_gst1_LogFunction),
+		C.gpointer(ptr),
+		(C.GDestroyNotify)((*[0]byte)(C.destroyUserdata)),
+	)
+
+	return LogFunctionHandle(ptr)
+}
+
+// DebugRemoveLogFunction wraps gst_debug_remove_log_function_by_data.
+//
+// See https://gstreamer.freedesktop.org/documentation/gstreamer/gstinfo.html?gi-language=c#gst_debug_remove_log_function_by_data
+//
+// Returns the number of functions removed.
+func DebugRemoveLogFunction(handle LogFunctionHandle) uint {
+	if handle == nil {
+		return 0
+	}
+	ret := C.gst_debug_remove_log_function_by_data(C.gpointer(handle))
+	return uint(ret)
+}
+
+// DebugRemoveDefaultLogFunction removes GStreamer's default log function (gst_debug_log_default).
+// Returns the number of functions removed.
+func DebugRemoveDefaultLogFunction() uint {
+	return uint(C.gst_debug_remove_log_function((*[0]byte)(C.gst_debug_log_default)))
+}
+
+// DebugAddDefaultLogFunction re-adds GStreamer's default log function (gst_debug_log_default).
+// Note: calling this multiple times will register the default function multiple times.
+func DebugAddDefaultLogFunction() {
+	C.gst_debug_add_log_function((*[0]byte)(C.gst_debug_log_default), nil, nil)
+}


### PR DESCRIPTION
The new generated bindings only provide a way to add an additional log function alongside the existing default log function. The handwritten bindings used to provide a way to override the default log function. This patch adds back that functionality.